### PR TITLE
Feature/isamu dev2

### DIFF
--- a/src/config/firebase.js
+++ b/src/config/firebase.js
@@ -1,0 +1,9 @@
+export default {
+  apiKey: "",
+  authDomain: "",
+  databaseURL: "",
+  projectId: "",
+  storageBucket: "",
+  messagingSenderId: "",
+  appId: ""
+};

--- a/src/layouts/default.vue
+++ b/src/layouts/default.vue
@@ -56,7 +56,7 @@
     </b-navbar>
 
     <!-- pagesのコンポーネントが読み込まれる -->
-    <nuxt style="max-width:100%;"></nuxt>
+    <nuxt style="max-width:100%;" v-if="loaded" ></nuxt>
     <!-- pagesのコンポーネントが読み込まれる -->
 
     <footer class="footer" style="background-color: black!important;">
@@ -141,7 +141,10 @@
 </template>
 
 <script>
+import { auth } from '@/plugins/firebase.js';
+
 export default {
+
   data() {
     return {
       items: [
@@ -157,6 +160,20 @@ export default {
         }
       ]
     };
+  },
+  computed: {
+    loaded() {
+      return !this.$store.getters['user/loading'];
+    },
+  },
+  beforeCreate() {
+    this.$store.commit('user/SET_LOADING', true);
+    auth.onAuthStateChanged(user => {
+      if (user) {
+        this.$store.commit('user/SET_USER', user);
+      }
+      this.$store.commit('user/SET_LOADING', false);
+    });
   }
 };
 </script>

--- a/src/pages/admin/restaurants/index.vue
+++ b/src/pages/admin/restaurants/index.vue
@@ -68,8 +68,8 @@ export default {
   computed: {},
   mounted() {
     const uid = this.$store.getters['user/user'].uid;
-    console.log(uid);
     db.collection("restaurants")
+      .where("uid", "==", uid)
       .get()
       .then(data => {
         data.forEach(doc => {

--- a/src/pages/admin/restaurants/index.vue
+++ b/src/pages/admin/restaurants/index.vue
@@ -67,6 +67,8 @@ export default {
   },
   computed: {},
   mounted() {
+    const uid = this.$store.getters['user/user'].uid;
+    console.log(uid);
     db.collection("restaurants")
       .get()
       .then(data => {

--- a/src/pages/admin/restaurants/new.vue
+++ b/src/pages/admin/restaurants/new.vue
@@ -334,6 +334,7 @@ export default {
     VueTagsInput
   },
   data() {
+    const uid = this.$store.getters['user/user'].uid;
     return {
       restProfileCroppa: null,
       restCoverCroppa: null,
@@ -346,7 +347,7 @@ export default {
       url: "",
       // tags: "",
       states: US_STATES,
-      uid: "hogehoge", //TODO test
+      uid: uid,
       hoursMon: true,
       hoursTue: true,
       hoursWed: true,

--- a/src/plugins/firebase.js
+++ b/src/plugins/firebase.js
@@ -1,17 +1,11 @@
 import firebase from "firebase";
+import firebaseConfig from "@/config/firebase";
 
 // ** 本番環境
 if (!firebase.apps.length) {
-  firebase.initializeApp({
-    apiKey: "",
-    authDomain: "",
-    databaseURL: "",
-    projectId: "",
-    storageBucket: "",
-    messagingSenderId: "",
-    appId: ""
-  });
+  firebase.initializeApp(firebaseConfig);
 }
 
 export const db = firebase.firestore();
 export const storage = firebase.storage();
+export const auth = firebase.auth();

--- a/src/store/user/index.js
+++ b/src/store/user/index.js
@@ -4,7 +4,7 @@ import { db } from "~/plugins/firebase.js";
 export default {
   state: {
     user: null,
-    loading: false,
+    loading: true,
     error: null
   },
   mutations: {


### PR DESCRIPTION
全てのページを読み込む前にfirebaseのユーザを取得するようにしました。
通常のログインページでログインしてクッキー等で認証情報持っていると、全てのページでユーザ情報が使えます。

Firebaseの設定を
src/config/firebase.js
に移動しました。マージ後は気をつけてください。

現状、ユーザ情報を　'user/user'　にセットしていますが、
ユーザ系を'user/user'、管理系を'admin/user'にして、
storeは１つ、moduleでデータを分けるようにしようと思います。どうでしょう？
管理系はメアド認証、ユーザ系はSMS認証なので、そこをチェックしてセットしようと思います。

Firebaseでもrulesのfunctionで上記判定を作って、CRUDの制限をする予定です。

問題があればツッコミ/コメントをお願いします。


