### PR TITLE
support ogp

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -18,6 +18,10 @@
     ],
     "rewrites": [
       {
+        "source": "/r/*",
+        "function": "api"
+      },
+      {
         "source": "**",
         "destination": "/index.html"
       }

--- a/functions/package.json
+++ b/functions/package.json
@@ -14,6 +14,7 @@
   },
   "main": "lib/index.js",
   "dependencies": {
+    "express": "^4.17.1",
     "firebase-admin": "^8.0.0",
     "firebase-functions": "^3.1.0"
   },

--- a/functions/src/functions/express.ts
+++ b/functions/src/functions/express.ts
@@ -1,0 +1,71 @@
+import * as express from 'express';
+import * as admin from 'firebase-admin';
+import * as fs from 'fs';
+
+export const app = express();
+export const router = express.Router();
+
+// for test, db is not immutable
+if (!admin.apps.length) {
+  admin.initializeApp();
+}
+
+//let db = admin.firestore();
+//export const updateDb = (_db) => {
+//  db = _db;
+//}
+
+export const logger = async (req, res, next) => {
+  next();
+}
+export const hello_response = async (req, res) =>{
+  res.json({message: "hello"});
+};
+
+const ogpPage = async (req: any, res: any) => {
+  const { restaurantName } = req.params;
+
+  const escapeHtml = (str: string): string => {
+    if (typeof str !== 'string') {
+      return '';
+    }
+    const mapping:any = {
+      '&': '&amp;',
+      "'": '&#x27;',
+      '`': '&#x60;',
+      '"': '&quot;',
+      '<': '&lt;',
+      '>': '&gt;',
+    };
+    return str.replace(/[&'`"<>]/g, function(match) {
+      return mapping[match]
+    });
+  }
+
+  const title = "Adana Restaurant";
+
+  res.set('Cache-Control', 'public, max-age=300, s-maxage=600');
+  fs.readFile('./templates/index.html', 'utf8', (err, data) => {
+    const regex = /<title.*title>/
+    const metas =
+      [
+        `<title>${escapeHtml(title)}</title>`,
+        `<meta property="og:title" content="${escapeHtml(title)}" />`,
+        `<meta property="og:site_name" content="${escapeHtml(title)}" />`,
+        `<meta property="og:type" content="website" />`,
+        `<meta property="og:url" content="https://staging.ownplate.today/r/${restaurantName}" />`,
+        `<meta property="og:description" content="Japanese comfort food" />`,
+        `<meta property="og:image" content="https://static.wixstatic.com/media/bafa8d_9cd1d487e24140aba7b6885e198cb62e~mv2_d_4928_3264_s_4_2.jpg/v1/fill/w_980,h_1350,al_c,q_85,usm_0.66_1.00_0.01/bafa8d_9cd1d487e24140aba7b6885e198cb62e~mv2_d_4928_3264_s_4_2.webp" />`,
+      ].join("\n");
+    res.send(data.replace(regex, metas));
+  });
+};
+
+router.get('/hello',
+           logger,
+           hello_response);
+
+app.use('/1.0', router);
+
+app.get('/r/:restaurantName', ogpPage);
+app.get('/r/:restaurantpName/*', ogpPage);

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -1,8 +1,5 @@
 import * as functions from 'firebase-functions';
 
-// // Start writing Firebase Functions
-// // https://firebase.google.com/docs/functions/typescript
-//
-// export const helloWorld = functions.https.onRequest((request, response) => {
-//  response.send("Hello from Firebase!");
-// });
+import * as express from './functions/express';
+
+export const api = functions.https.onRequest(express.app);

--- a/functions/tsconfig.json
+++ b/functions/tsconfig.json
@@ -3,6 +3,7 @@
     "module": "commonjs",
     "noImplicitReturns": true,
     "noUnusedLocals": true,
+    "noImplicitAny": false,
     "outDir": "lib",
     "sourceMap": true,
     "strict": true,

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "nakajima-demae",
+  "name": "OwnPlate",
   "version": "1.0.0",
-  "description": "My stylish Nuxt.js project",
+  "description": "OwnPlate - Delicious food",
   "author": "FujiyamaYuta",
   "private": true,
   "scripts": {
@@ -13,7 +13,7 @@
     "lint": "eslint --ext .js,.vue --ignore-path .gitignore .",
     "lintfix": "eslint --fix --ext .js,.vue --ignore-path .gitignore .",
     "deploy_stating": "nuxt build &&  firebase deploy --only hosting --project=staging",
-    "deploy": "nuxt build &&  firebase deploy --only hosting --project=staging"
+    "deploy": "nuxt build && cp dist/index.html functions/templates/index.html &&  firebase deploy --only hosting --project=staging"
   },
   "dependencies": {
     "@babel/plugin-syntax-dynamic-import": "^7.7.4",


### PR DESCRIPTION
ogpサポートしました。
nuxt側でのデプロイスクリプトで、
cp dist/index.html functions/templates/index.html 
と、index.htmlをfunctionsにコピーします。

functionsではexpressで、index.htmlのヘッダーを書き換えて、必要なメタ情報を追加して返すようにしています。

firebase.jsonのrewrite ruleで必要な箇所だけ、functionsを呼ぶようにしています。

どのページでも、結局はindex.htmlを返すので、nuxt側の挙動に影響はなく、初回ロードは遅くなりますが、jsで遷移している限りはパフォーマンスに影響はありません。

nuxtを変更したときに、deployスクリプトを通してfunctionsを変更しないと、ogp該当ページの挙動がおかしくなるので要注意です（これは、CIでデプロイすれば問題なくなります）
