### PR TITLE
Itemcard changes2

### DIFF
--- a/src/components/ItemCard.vue
+++ b/src/components/ItemCard.vue
@@ -10,7 +10,7 @@
           <h2 class="bold payment">
             {{ payment }}
           </h2>
-          <p>{{ discription }}</p>
+          <p>{{ description }}</p>
         </div>
         <div class="media-right">
           <figure class="image is-100x100">
@@ -124,7 +124,7 @@ export default {
       type: String,
       required: true
     },
-    discription: {
+    description: {
       type: String,
       required: true
     },

--- a/src/components/ItemCard.vue
+++ b/src/components/ItemCard.vue
@@ -116,6 +116,14 @@ import store from "~/store/index.js";
 import { mapGetters, mapMutations } from "vuex";
 export default {
   props: {
+    id: {
+      type: String,
+      required: true
+    },
+    counter: {
+      type: Number,
+      required: true
+    },
     title: {
       type: String,
       required: true
@@ -136,7 +144,6 @@ export default {
   },
   data() {
     return {
-      counter: 0,
       openMenuFlag: false
     };
   },
@@ -145,31 +152,28 @@ export default {
       if (this.counter <= 0) {
         return;
       }
-      this.counter--;
       this.$store.state.totalOrderCount--;
-      this.order();
+      this.order(this.counter - 1);
       console.log(this.$store.state.totalOrderCount);
     },
     pushCount() {
-      this.counter++;
       this.$store.state.totalOrderCount++;
-      this.order();
+      this.order(this.counter + 1);
       console.log(this.$store.state.totalOrderCount);
     },
     openMenu() {
       this.openMenuFlag = true;
       if (this.counter == 0) {
-        this.counter++;
         this.$store.state.totalOrderCount++;
-        this.order();
+        this.order(this.counter + 1);
         console.log(this.$store.state.totalOrderCount);
       }
     },
     closeMenu() {
       this.openMenuFlag = false;
     },
-    order() {
-      this.$emit("emitting", { orderCount: this.$store.state.totalOrderCount });
+    order(newCounter) {
+      this.$emit("emitting", { id:this.id, counter:newCounter, orderCount: this.$store.state.totalOrderCount });
     }
   }
 };

--- a/src/pages/restaurants/menu/_id.vue
+++ b/src/pages/restaurants/menu/_id.vue
@@ -16,34 +16,13 @@
         <b-tab-item label="Menu">
           <h2 class="p-big bold">Most popular</h2>
 
-          <!-- TODO - for -->
-          <item-card
-            :title="'Kushikatsu Special Platter'"
-            :payment="'$26.00'"
-            :discription="
-              '11 pieces assorted kushikatsu. Served with miso soup and salad.'
-            "
-            :image="'https://magazine.hitosara.com/image/421/MM_421.jpg'"
-            @emitting="emitted($event)"
-          ></item-card>
-          <item-card
-            :title="'Spicy Eggplant'"
-            :payment="'$8.00'"
-            :discription="
-              'Steamed topped with assorted fresh roe and special sauce.'
-            "
-            :image="'https://magazine.hitosara.com/image/421/MM_421.jpg'"
-            @emitting="emitted($event)"
-          ></item-card>
-          <item-card
-            :title="'Spicy Eggplant'"
-            :payment="'$8.00'"
-            :discription="
-              'Steamed topped with assorted fresh roe and special sauce.'
-            "
-            :image="
-              'https://www.momoya.co.jp/wp-content/uploads/2016/01/%E6%B8%88%EF%BC%97.jpg'
-            "
+          <item-card 
+            v-for="item in popularItems"
+            v-bind:key="item.id"
+            v-bind:title="item.title"
+            v-bind:payment="item.payment"
+            v-bind:discription="item.discrirption"
+            v-bind:image="item.image"
             @emitting="emitted($event)"
           ></item-card>
 
@@ -129,6 +108,25 @@ export default {
   },
   data() {
     return {
+      popularItems: [{
+        id:"1001",
+        title:"KUKushikatsu Special Platter",
+        payment:"$26.00",
+        discription:"11 pieces assorted kushikatsu. Served with miso soup and salad.",
+        image:"https://magazine.hitosara.com/image/421/MM_421.jpg",
+      },{
+        id:"1002",
+        title:"Spicy Eggplant",
+        payment:"$8.00",
+        discription:"Steamed topped with assorted fresh roe and special sauce.",
+        image:"https://magazine.hitosara.com/image/421/MM_421.jpg"
+      },{
+        id:"1003",
+        title:"Spicy Eggplant",
+        payment:"$8.00",
+        discription:"Steamed topped with assorted fresh roe and special sauce.",
+        image:"https://www.momoya.co.jp/wp-content/uploads/2016/01/%E6%B8%88%EF%BC%97.jpg"
+      }],
       footCounter: this.$store.state.totalOrderCount,
       restaurantsId: this.$route.params.id
       // isCardModalActive: false

--- a/src/pages/restaurants/menu/_id.vue
+++ b/src/pages/restaurants/menu/_id.vue
@@ -19,6 +19,8 @@
           <item-card 
             v-for="item in appetizers"
             v-bind:key="item.id"
+            v-bind:id="item.id"
+            v-bind:counter="orders[item.id] || 0"
             v-bind:title="item.title"
             v-bind:payment="item.payment"
             v-bind:description="item.description"
@@ -32,6 +34,8 @@
           <item-card 
             v-for="item in entrees"
             v-bind:key="item.id"
+            v-bind:id="item.id"
+            v-bind:counter="orders[item.id] || 0"
             v-bind:title="item.title"
             v-bind:payment="item.payment"
             v-bind:description="item.description"
@@ -109,6 +113,7 @@ export default {
         description:"Boiled Soy Beans",
         image:"https://www.olive-hitomawashi.com/column/assets_c/2017/12/SEO058K_0-thumb-500xauto-50342.jpg",
       }],
+      orders: {},
       footCounter: this.$store.state.totalOrderCount,
       restaurantsId: this.$route.params.id
       // isCardModalActive: false
@@ -125,6 +130,7 @@ export default {
   },
   methods: {
     emitted(eventArgs) {
+      this.orders[eventArgs.id] = eventArgs.counter;
       this.footCounter = eventArgs.orderCount;
       // console.log(eventArgs.orderCount);
     },

--- a/src/pages/restaurants/menu/_id.vue
+++ b/src/pages/restaurants/menu/_id.vue
@@ -88,12 +88,12 @@ export default {
         title:"Spicy Eggplant",
         payment:"$8.00",
         discription:"Steamed topped with assorted fresh roe and special sauce.",
-        image:"https://magazine.hitosara.com/image/421/MM_421.jpg"
+        image:"https://demandafrica-4741.kxcdn.com/wp-content/uploads/2017/08/Spicy-Chinese-Eggplant.jpg"
       },{
         id:"1003",
-        title:"Spicy Eggplant",
+        title:"Oyako-don",
         payment:"$8.00",
-        discription:"Steamed topped with assorted fresh roe and special sauce.",
+        discription:"Chiken and Egg on Rice.",
         image:"https://www.momoya.co.jp/wp-content/uploads/2016/01/%E6%B8%88%EF%BC%97.jpg"
       }],
       appetizers: [{

--- a/src/pages/restaurants/menu/_id.vue
+++ b/src/pages/restaurants/menu/_id.vue
@@ -21,7 +21,7 @@
             v-bind:key="item.id"
             v-bind:title="item.title"
             v-bind:payment="item.payment"
-            v-bind:discription="item.discrirption"
+            v-bind:discription="item.discription"
             v-bind:image="item.image"
             @emitting="emitted($event)"
           ></item-card>
@@ -29,47 +29,16 @@
           <hr class="hr-black" />
 
           <h2 class="p-big bold">Appetizers</h2>
-          <!-- TODO - for -->
-          <item-card
-            :title="'Kushikatsu Special Platter'"
-            :payment="'$26.00'"
-            :discription="
-              '11 pieces assorted kushikatsu. Served with miso soup and salad.'
-            "
-            :image="'https://magazine.hitosara.com/image/421/MM_421.jpg'"
+          <item-card 
+            v-for="item in appetizers"
+            v-bind:key="item.id"
+            v-bind:title="item.title"
+            v-bind:payment="item.payment"
+            v-bind:discription="item.discription"
+            v-bind:image="item.image"
             @emitting="emitted($event)"
           ></item-card>
-          <item-card
-            :title="'Spicy Eggplant'"
-            :payment="'$8.00'"
-            :discription="
-              'Steamed topped with assorted fresh roe and special sauce.'
-            "
-            :image="'https://magazine.hitosara.com/image/421/MM_421.jpg'"
-            @emitting="emitted($event)"
-          ></item-card>
-          <item-card
-            :title="'Spicy Eggplant'"
-            :payment="'$8.00'"
-            :discription="
-              'Steamed topped with assorted fresh roe and special sauce.'
-            "
-            :image="
-              'https://www.momoya.co.jp/wp-content/uploads/2016/01/%E6%B8%88%EF%BC%97.jpg'
-            "
-            @emitting="emitted($event)"
-          ></item-card>
-          <item-card
-            :title="'Chicken Karaage'"
-            :payment="'$9.95'"
-            :discription="'Chicken Karaage'"
-            @emitting="emitted($event)"
-          ></item-card>
-          <item-card
-            :title="'Edamame'"
-            :payment="'$3.00'"
-            @emitting="emitted($event)"
-          ></item-card>
+
         </b-tab-item>
         <b-tab-item label="About">
           <shop-info></shop-info>
@@ -110,7 +79,7 @@ export default {
     return {
       popularItems: [{
         id:"1001",
-        title:"KUKushikatsu Special Platter",
+        title:"Kushikatsu Special Platter",
         payment:"$26.00",
         discription:"11 pieces assorted kushikatsu. Served with miso soup and salad.",
         image:"https://magazine.hitosara.com/image/421/MM_421.jpg",
@@ -126,6 +95,19 @@ export default {
         payment:"$8.00",
         discription:"Steamed topped with assorted fresh roe and special sauce.",
         image:"https://www.momoya.co.jp/wp-content/uploads/2016/01/%E6%B8%88%EF%BC%97.jpg"
+      }],
+      appetizers: [{
+        id:"1004",
+        title:"Chicken Karaage",
+        payment:"$9.95",
+        discription:"Chicken Karaage",
+        image:"https://img.cpcdn.com/recipes/4417485/280x487s/e4e40823fa78ca87df83284c5ecc5cf2.jpg"
+      },{
+        id:"1005",
+        title:"Edamame",
+        payment:"$3.00",
+        discription:"Boiled Soy Beans",
+        image:"https://www.olive-hitomawashi.com/column/assets_c/2017/12/SEO058K_0-thumb-500xauto-50342.jpg",
       }],
       footCounter: this.$store.state.totalOrderCount,
       restaurantsId: this.$route.params.id

--- a/src/pages/restaurants/menu/_id.vue
+++ b/src/pages/restaurants/menu/_id.vue
@@ -14,27 +14,27 @@
       ></shop-orner-info>
       <b-tabs size="is-medium" class="block" expanded>
         <b-tab-item label="Menu">
-          <h2 class="p-big bold">Most popular</h2>
+          <h2 class="p-big bold">Appetizers</h2>
 
           <item-card 
-            v-for="item in popularItems"
+            v-for="item in appetizers"
             v-bind:key="item.id"
             v-bind:title="item.title"
             v-bind:payment="item.payment"
-            v-bind:discription="item.discription"
+            v-bind:description="item.description"
             v-bind:image="item.image"
             @emitting="emitted($event)"
           ></item-card>
 
           <hr class="hr-black" />
 
-          <h2 class="p-big bold">Appetizers</h2>
+          <h2 class="p-big bold">Entrees</h2>
           <item-card 
-            v-for="item in appetizers"
+            v-for="item in entrees"
             v-bind:key="item.id"
             v-bind:title="item.title"
             v-bind:payment="item.payment"
-            v-bind:discription="item.discription"
+            v-bind:description="item.description"
             v-bind:image="item.image"
             @emitting="emitted($event)"
           ></item-card>
@@ -77,36 +77,36 @@ export default {
   },
   data() {
     return {
-      popularItems: [{
+      entrees: [{
         id:"1001",
         title:"Kushikatsu Special Platter",
         payment:"$26.00",
-        discription:"11 pieces assorted kushikatsu. Served with miso soup and salad.",
+        description:"11 pieces assorted kushikatsu. Served with miso soup and salad.",
         image:"https://magazine.hitosara.com/image/421/MM_421.jpg",
       },{
         id:"1002",
         title:"Spicy Eggplant",
         payment:"$8.00",
-        discription:"Steamed topped with assorted fresh roe and special sauce.",
+        description:"Steamed topped with assorted fresh roe and special sauce.",
         image:"https://demandafrica-4741.kxcdn.com/wp-content/uploads/2017/08/Spicy-Chinese-Eggplant.jpg"
       },{
         id:"1003",
         title:"Oyako-don",
         payment:"$8.00",
-        discription:"Chiken and Egg on Rice.",
+        description:"Chiken and Egg on Rice.",
         image:"https://www.momoya.co.jp/wp-content/uploads/2016/01/%E6%B8%88%EF%BC%97.jpg"
       }],
       appetizers: [{
         id:"1004",
         title:"Chicken Karaage",
         payment:"$9.95",
-        discription:"Chicken Karaage",
+        description:"Chicken Karaage",
         image:"https://img.cpcdn.com/recipes/4417485/280x487s/e4e40823fa78ca87df83284c5ecc5cf2.jpg"
       },{
         id:"1005",
         title:"Edamame",
         payment:"$3.00",
-        discription:"Boiled Soy Beans",
+        description:"Boiled Soy Beans",
         image:"https://www.olive-hitomawashi.com/column/assets_c/2017/12/SEO058K_0-thumb-500xauto-50342.jpg",
       }],
       footCounter: this.$store.state.totalOrderCount,


### PR DESCRIPTION
counter を itemCard には持たず、親である menu (_id.vue) に orders というオブジェクトで持たせるようにしたものです。この方が、後に実際のオーダーを登録する時にも良いと思います。