### PR TITLE
Add trigger

### DIFF
--- a/functions/package.json
+++ b/functions/package.json
@@ -6,6 +6,7 @@
     "serve": "npm run build && firebase serve --only functions",
     "shell": "npm run build && firebase functions:shell",
     "start": "npm run shell",
+    "deploy_fs": "firebase deploy --only functions:orderCreate",
     "deploy": "firebase deploy --only functions",
     "logs": "firebase functions:log",
     "tests": "NODE_ENV=test mocha -r ts-node/register  --recursive tests/*_test.ts"

--- a/functions/src/common/constant.ts
+++ b/functions/src/common/constant.ts
@@ -1,0 +1,17 @@
+export const order_status = {
+  error: 0,
+  new_order: 100, // by user
+  validation_ok: 200, // by functions
+  customer_paid: 300,  // by user and stripe
+  order_accepted: 400, // by restaurant
+  cooking_completed: 500, // by restaurant
+  customer_picked_up: 600, // by restaurant
+};
+
+export const order_error = {
+  validation_error: 100,
+  order_canceled_by_customer: 200,
+  payment_error: 300,
+  order_canceled_by_restaurant: 400,
+  unknow_error: 900,
+};

--- a/functions/src/functions/firestore.ts
+++ b/functions/src/functions/firestore.ts
@@ -1,0 +1,9 @@
+export const orderCreate = async (db, snapshot, context) => {
+  // const { restaurantId, orderId } = context.params;
+
+  // todo validate order data
+
+  // todo create stripe payment request
+
+  snapshot.ref.update({status: 200});
+}

--- a/functions/src/functions/firestore.ts
+++ b/functions/src/functions/firestore.ts
@@ -1,9 +1,24 @@
+import * as constant from '../common/constant';
+
 export const orderCreate = async (db, snapshot, context) => {
   // const { restaurantId, orderId } = context.params;
-
+  const original_data = snapshot.data()
   // todo validate order data
+  if (!original_data || !original_data.status || original_data.status !== constant.order_status.new_order) {
+    return ;
+  }
+
+  // todo calculate price.
+  const sub_total = 2000;
+  const tax = 200;
+  const total = sub_total+ tax;
 
   // todo create stripe payment request
+  snapshot.ref.update({
+    status: constant.order_status.validation_ok,
 
-  snapshot.ref.update({status: 200});
+    sub_total,
+    tax,
+    total
+  });
 }

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -1,5 +1,17 @@
+import * as admin from 'firebase-admin';
 import * as functions from 'firebase-functions';
 
 import * as express from './functions/express';
+import * as firestore from './functions/firestore';
+
 
 export const api = functions.https.onRequest(express.app);
+
+let db = admin.firestore();
+export const updateDb = (_db) => {
+  db = _db;
+}
+
+export const orderCreate = functions.firestore.document('restaurants/{restaurantId}/orders/{orderId}').onCreate(async (snapshot, context)=>{
+  await firestore.orderCreate(db, snapshot, context);
+});

--- a/src/pages/r/_restaurantId/index.vue
+++ b/src/pages/r/_restaurantId/index.vue
@@ -72,6 +72,7 @@ import ShopOrnerInfo from "~/components/ShopOrnerInfo";
 import ShopInfo from "~/components/ShopInfo";
 
 import { db } from "~/plugins/firebase.js";
+import { order_status } from "~/plugins/constant.js";
 
 export default {
   name: "ShopMenu",
@@ -176,7 +177,7 @@ export default {
     async checkOut() {
       const order_data = {
         order: this.orders,
-        statis: 0, // todo
+        status: order_status.new_order,
         uid: "hogehoge", // todo
         // price never set here.
       };

--- a/src/plugins/constant.js
+++ b/src/plugins/constant.js
@@ -1,0 +1,17 @@
+export const order_status = {
+  error: 0,
+  new_order: 100, // by user
+  validation_ok: 200, // by functions
+  customer_paid: 300,  // by user and stripe
+  order_accepted: 400, // by restaurant
+  cooking_completed: 500, // by restaurant
+  customer_picked_up: 600, // by restaurant
+};
+
+export const order_error = {
+  validation_error: 100,
+  order_canceled_by_customer: 200,
+  payment_error: 300,
+  order_canceled_by_restaurant: 400,
+  unknow_error: 900,
+};


### PR DESCRIPTION
ユーザ側の画面でorderをfirestoreに入れるようにしました（開発のために仮で）

firestoreにorderが追加されると、triggerでfunctionが動いて、
オーダーの妥当性のチェック
合計金額の計算
Stripeの処理
statusの更新
をします（ここはまだ未実装）

ユーザ側では、order.idを元に、docをlistenして、statusが更新されたら決済の処理が可能になります。

