### PR TITLE
rules V2, disallow create

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -1,3 +1,4 @@
+rules_version = '2';
 service cloud.firestore {
   match /databases/{database}/documents {
     function isAdmin(request) {
@@ -18,7 +19,7 @@ service cloud.firestore {
 
     match /restaurants/{restaurantsId} {
       allow read: if true
-      allow create: if isAdmin(request);
+      // allow create: if isAdmin(request);
       allow update: if isAdmin(request) && isOwner(resource, request);
     }
 


### PR DESCRIPTION
1. restaurants/{restaurantsId} へのクライアントからの書き込みを禁止しました 
2. firebase.rules を version 2 にアップデートしました（ワイルドカードの扱いが変わりました）
