### PR TITLE
link material icon explicitly

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -55,6 +55,10 @@ export default {
       },
       {
         rel: "stylesheet",
+        href: "https://cdn.materialdesignicons.com/2.5.94/css/materialdesignicons.min.css"
+      },
+      {
+        rel: "stylesheet",
         href: "https://use.fontawesome.com/releases/v5.2.0/css/all.css"
       }
     ]

--- a/src/assets/scss/main.scss
+++ b/src/assets/scss/main.scss
@@ -1,4 +1,33 @@
+// Import Bulma's core
+@import "~bulma/sass/utilities/_all";
+
+// Set your colors
 $info : #ff0000;
+$info-invert: findColorInvert($info);
+$primary: #8c67ef;
+$primary-invert: findColorInvert($primary);
+$twitter: #4099FF;
+$twitter-invert: findColorInvert($twitter);
+
+// Setup $colors to use as bulma classes (e.g. 'is-twitter')
+$colors: (
+    "white": ($white, $black),
+    "black": ($black, $white),
+    "light": ($light, $light-invert),
+    "dark": ($dark, $dark-invert),
+    "primary": ($primary, $primary-invert),
+    "info": ($info, $info-invert),
+    "success": ($success, $success-invert),
+    "warning": ($warning, $warning-invert),
+    "danger": ($danger, $danger-invert),
+    "twitter": ($twitter, $twitter-invert)
+);
+
+// Links
+$link: $primary;
+$link-invert: $primary-invert;
+$link-focus-border: $primary;
+
 @import "~bulma";
 @import "~buefy/src/scss/buefy";
 


### PR DESCRIPTION
Material Icon が表示されない問題を解決しました。Buefy をカスタマイズするために "next-buefy" を nuxt.config.js の module から外したのですが、その結果、material icon が import されなくなってしまったのです。Nuxt の黒魔術は便利で良いのですが、こんな風にカスタマイズしたい場合などに逆に手間がかかります。