### PR TITLE
removed orderId mixin

### DIFF
--- a/src/pages/admin/restaurants/_restaurantId/orders/_orderId/index.vue
+++ b/src/pages/admin/restaurants/_restaurantId/orders/_orderId/index.vue
@@ -59,7 +59,7 @@ export default {
         this.menus = this.array2obj(menuList);
       }
     });
-    const order_detacher = db.doc(`restaurants/${this.restaurantId()}/orders/${this.orderId()}`).onSnapshot((order) => {
+    const order_detacher = db.doc(`restaurants/${this.restaurantId()}/orders/${this.orderId}`).onSnapshot((order) => {
       if (order.exists) {
         const order_data = order.data();
         this.orderInfo = order_data;
@@ -82,6 +82,9 @@ export default {
     },
     count() {
       return this.ids ? this.ids.length : 0;
+    },
+    orderId() {
+      return this.$route.params.orderId;
     }
   },
   methods: {
@@ -92,7 +95,7 @@ export default {
       }
     },
     async changeStatus(statusKey, event) {
-      const ref = db.doc(`restaurants/${this.restaurantId()}/orders/${this.orderId()}`);
+      const ref = db.doc(`restaurants/${this.restaurantId()}/orders/${this.orderId}`);
       console.log(this.orderInfo);
       await ref.set({status:order_status[statusKey]}, {merge:true});
 

--- a/src/pages/r/_restaurantId/order/_orderId/index.vue
+++ b/src/pages/r/_restaurantId/order/_orderId/index.vue
@@ -87,7 +87,7 @@ export default {
         this.menus = menu.docs.map(this.doc2data("menu"));
       }
     });
-    const order_detacher = db.doc(`restaurants/${this.restaurantId()}/orders/${this.orderId()}`).onSnapshot((order) => {
+    const order_detacher = db.doc(`restaurants/${this.restaurantId()}/orders/${this.orderId}`).onSnapshot((order) => {
       if (order.exists) {
         const order_data = order.data();
         this.orderInfo = order_data;
@@ -114,6 +114,11 @@ export default {
       });
     }
   },
+  computed: {
+    orderId() {
+      return this.$route.params.orderId;
+    }
+  },
   methods: {
     updateOrder() {
       if (this.menus.length > 0 && this.orderInfo.order) {
@@ -130,7 +135,7 @@ export default {
     },
     goNext() {
       // this.$router.push({ path: "/restaurants/thank" });
-      this.$router.push({ path: `/r/${this.restaurantId()}/order/${this.orderId()}/thanks` });
+      this.$router.push({ path: `/r/${this.restaurantId()}/order/${this.orderId}/thanks` });
     }
   }
 };

--- a/src/plugins/utils.js
+++ b/src/plugins/utils.js
@@ -6,9 +6,6 @@ export default ({app}) => {
       restaurantId() {
         return this.$route.params.restaurantId;
       },
-      orderId() {
-        return this.$route.params.orderId;
-      },
       adminUid() {
         return this.$store.getters["admin/user"].uid;
       },


### PR DESCRIPTION
plugin/utils.vue で mixin している orderId ですが、LoginModal.vue の中のローカルの orderId と被っていました。やはり、この手のものを mixin すると事故が多いので、明示的にインポートするか、個々に定義するのが良いと思います。このケースでは、ここに定義してもたった三行なので、そちらにしました。また、method ではなく、computed にしています（２度目はキャッシュが使われます）。