### PR TITLE
Admin Restaurants View & Orders View

### DIFF
--- a/src/components/OrderedInfo.vue
+++ b/src/components/OrderedInfo.vue
@@ -46,7 +46,7 @@ export default {
   },
   computed: {
     timestamp() {
-      return this.order.timePaid.toDate().toLocaleTimeString();
+      return this.order.timePaid.toLocaleTimeString();
     },
     phoneNumber() {
       return this.order.phoneNumber && parsePhoneNumber(this.order.phoneNumber);

--- a/src/pages/admin/restaurants/_restaurantId/orders/index.vue
+++ b/src/pages/admin/restaurants/_restaurantId/orders/index.vue
@@ -42,9 +42,17 @@ export default {
     const order_detacher = db.collection(`restaurants/${this.restaurantId()}/orders`)
         .where("status", ">=", order_status.customer_paid)
         .where("status", "<", order_status.customer_picked_up)
-        .onSnapshot((orders) => {
-      if (!orders.empty) {
-        this.orders = orders.docs.map(this.doc2data("order"));
+        .onSnapshot((result) => {
+      if (!result.empty) {
+        let orders = result.docs.map(this.doc2data("order"));
+        orders = orders.map((order)=>{
+          order.timePaid = order.timePaid.toDate(); 
+          return order;
+        });
+        this.orders = orders.sort((order1, order2)=>{
+          console.log(order1.number, order1.timePaid, order2.timePaid)
+          return order1.timePaid - order2.timePaid;
+        });
       }
     });
     this.detachers = [

--- a/src/pages/admin/restaurants/_restaurantId/orders/index.vue
+++ b/src/pages/admin/restaurants/_restaurantId/orders/index.vue
@@ -40,7 +40,8 @@ export default {
       }
     });
     const order_detacher = db.collection(`restaurants/${this.restaurantId()}/orders`)
-        .where("status", ">", order_status.validation_ok)
+        .where("status", ">=", order_status.customer_paid)
+        .where("status", "<", order_status.customer_picked_up)
         .onSnapshot((orders) => {
       if (!orders.empty) {
         this.orders = orders.docs.map(this.doc2data("order"));


### PR DESCRIPTION
admin 用の UI の変更です。
- Restaurants ページの incomplete orders の数字をリアルタイム表示にしました
- Orders ページの表示を時間順（古いもの上）にしました。ソーティングはクライアント側で行なっています。
- どちらのページも、complete (customer_picked_up) は表示しないようにしました。