### PR TITLE
work-around special option

### DIFF
--- a/src/components/ItemCard.vue
+++ b/src/components/ItemCard.vue
@@ -124,10 +124,16 @@ export default {
   },
   computed: {
     options() {
+      // HACK: Dealing with a special case (probalby a bug in the menu editor)
+      if (
+        this.item.itemOptionCheckbox &&
+        this.item.itemOptionCheckbox.length === 1 &&
+        !this.item.itemOptionCheckbox[0]
+      ) {
+        console.log("Special case: itemOptionCheckbox===['']");
+        return [];
+      }
       return (this.item.itemOptionCheckbox || []).map(option => {
-        if (!option) {
-          return [];
-        }
         return option.split(",").map(choice => {
           return choice.trim();
         });


### PR DESCRIPTION
オプションがない場合に、空のチェックボックスが表示されてしまうバグですが、根本の問題は、オプションがない場合に、itemOptionCheckbox に[] ではなく [""] が 格納されているためでした（多分、menu editor のバグ）。なので、一つ前のPRは undo して（これは別のバグを導入します）、この問題を回避するために、[""]だった場合には、[]  として扱うように変更しました。