### PR TITLE
Server config: Region-specific Stripe option

### DIFF
--- a/functions/src/functions/system.ts
+++ b/functions/src/functions/system.ts
@@ -1,0 +1,8 @@
+import * as functions from 'firebase-functions'
+import * as utils from '../stripe/utils'
+
+export const getConfig = async (db: FirebaseFirestore.Firestore, data: any, context: functions.https.CallableContext) => {
+  return {
+    region: utils.region
+  }
+}

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -14,6 +14,11 @@ export const wasOrderCreated = functions.firestore.document('restaurants/{restau
   await Firestore.wasOrderCreated(db, snapshot, context);
 });
 
+import * as System from './functions/system';
+export const systemGetConfig = functions.https.onCall(async (data, context) => {
+  return await System.getConfig(db, data, context);
+});
+
 import * as Order from './functions/order';
 export const orderUpdate = functions.https.onCall(async (data, context) => {
   return await Order.update(db, data, context);

--- a/functions/src/stripe/utils.ts
+++ b/functions/src/stripe/utils.ts
@@ -3,7 +3,7 @@ import { stripe_regions } from '../common/constant'
 import Stripe from 'stripe'
 
 const locale = functions.config().locale;
-const region = (locale && locale.region) || "en";
+export const region = (locale && locale.region) || "us";
 export const stripe_region = stripe_regions[region] || stripe_regions["us"];
 
 export const validate_auth = (context: functions.https.CallableContext) => {

--- a/src/app/user/Order/OrderInfo.vue
+++ b/src/app/user/Order/OrderInfo.vue
@@ -117,7 +117,7 @@ export default {
   },
   watch: {
     orderInfo() {
-      console.log("orderInfo changed", this.orderInfo.total);
+      //console.log("orderInfo changed", this.orderInfo.total);
       this.updateTip(15);
     }
   },

--- a/src/app/user/Order/StripeCard.vue
+++ b/src/app/user/Order/StripeCard.vue
@@ -29,6 +29,11 @@ export default {
       this.configureStripe();
     }
   },
+  computed: {
+    stripeRegion() {
+      return this.$store.getters.stripeRegion;
+    }
+  },
   methods: {
     async createPaymentMethod() {
       const payload = await this.stripe.createPaymentMethod({
@@ -38,9 +43,10 @@ export default {
       return payload;
     },
     configureStripe() {
+      console.log("***3", this.stripeRegion);
       const elements = this.stripe.elements();
       const cardElement = elements.create("card", {
-        hidePostalCode: true,
+        hidePostalCode: this.stripeRegion.hidePostalCode,
         style: {
           base: {
             fontWeight: 600,

--- a/src/app/user/Order/StripeCard.vue
+++ b/src/app/user/Order/StripeCard.vue
@@ -39,8 +39,9 @@ export default {
     },
     configureStripe() {
       const elements = this.stripe.elements();
+      const stripeRegion = this.$store.getters.stripeRegion;
       const cardElement = elements.create("card", {
-        hidePostalCode: true,
+        hidePostalCode: stripeRegion.hidePostalCode,
         style: {
           base: {
             fontWeight: 600,

--- a/src/app/user/Order/StripeCard.vue
+++ b/src/app/user/Order/StripeCard.vue
@@ -29,11 +29,6 @@ export default {
       this.configureStripe();
     }
   },
-  computed: {
-    stripeRegion() {
-      return this.$store.getters.stripeRegion;
-    }
-  },
   methods: {
     async createPaymentMethod() {
       const payload = await this.stripe.createPaymentMethod({
@@ -43,10 +38,9 @@ export default {
       return payload;
     },
     configureStripe() {
-      console.log("***3", this.stripeRegion);
       const elements = this.stripe.elements();
       const cardElement = elements.create("card", {
-        hidePostalCode: this.stripeRegion.hidePostalCode,
+        hidePostalCode: true,
         style: {
           base: {
             fontWeight: 600,

--- a/src/app/user/OrderPage.vue
+++ b/src/app/user/OrderPage.vue
@@ -196,7 +196,7 @@ export default {
   },
   computed: {
     showPayment() {
-      console.log("payment", releaseConfig.hidePayment, this.stripeAccount);
+      //console.log("payment", releaseConfig.hidePayment, this.stripeAccount);
       return !releaseConfig.hidePayment && this.stripeAccount;
     },
     orderName() {
@@ -242,7 +242,7 @@ export default {
   },
   methods: {
     handleTipChange(tip) {
-      console.log("handleTipChange", tip);
+      //console.log("handleTipChange", tip);
       this.tip = tip;
     },
     handleCardStateChange(state) {

--- a/src/layouts/default.vue
+++ b/src/layouts/default.vue
@@ -56,7 +56,7 @@
 </template>
 
 <script>
-import { db, auth } from "@/plugins/firebase.js";
+import { db, auth, functions } from "@/plugins/firebase.js";
 
 export default {
   data() {
@@ -95,6 +95,11 @@ export default {
     }
   },
   beforeCreate() {
+    const systemGetConfig = functions.httpsCallable("systemGetConfig");
+    systemGetConfig().then(result => {
+      this.$store.commit("setServerConfig", result.data);
+    });
+
     this.unregisterAuthObserver = auth.onAuthStateChanged(async user => {
       if (user) {
         console.log(

--- a/src/plugins/constant.js
+++ b/src/plugins/constant.js
@@ -21,11 +21,13 @@ export const order_error = {
 export const stripe_regions = {
   "us": {
     currency: 'USD',
-    multiple: 100
+    multiple: 100,
+    hidePostalCode: false
   },
-  "ja": {
+  "jp": {
     currency: 'JPY',
-    multiple: 1
+    multiple: 1,
+    hidePostalCode: true
   }
 };
 

--- a/src/plugins/stripe.js
+++ b/src/plugins/stripe.js
@@ -14,4 +14,3 @@ export const stripeCancelIntent
   = functions.httpsCallable("stripeCancelIntent");
 export const stripeConnect = functions.httpsCallable("stripeConnect");
 export const stripeDisconnect = functions.httpsCallable("stripeDisconnect");
-

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -1,5 +1,6 @@
 import Vue from "vue";
 import Vuex from "vuex";
+import { stripe_regions } from "~/plugins/constant.js"
 
 Vue.use(Vuex);
 
@@ -8,7 +9,8 @@ export const strict = false;
 export const state = () => ({
   user: undefined, // undefined:not authorized, null:no user
   date: new Date(),
-  carts: {} // for "Edit Order"
+  carts: {}, // for "Edit Order"
+  server: {} // server configuration
 });
 
 export const getters = {
@@ -27,6 +29,11 @@ export const getters = {
   },
   name: (state) => {
     return state.user && state.user.name || "";
+  },
+  stripeRegion: (state) => {
+    console.log("***", state.server, stripe_regions, state.server.region)
+    console.log("***3", stripe_regions[state.server.region || "us"])
+    return stripe_regions[state.server.region || "us"]
   }
 };
 
@@ -41,6 +48,10 @@ export const mutations = {
     console.log("saving cart", payload.id, payload.cart);
     state.carts = {};
     state.carts[payload.id] = payload.cart;
+  },
+  setServerConfig(state, config) {
+    state.server = config;
+    console.log("setServerConfig", state.server.region)
   }
 };
 

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -31,8 +31,6 @@ export const getters = {
     return state.user && state.user.name || "";
   },
   stripeRegion: (state) => {
-    console.log("***", state.server, stripe_regions, state.server.region)
-    console.log("***3", stripe_regions[state.server.region || "us"])
     return stripe_regions[state.server.region || "us"]
   }
 };
@@ -51,7 +49,7 @@ export const mutations = {
   },
   setServerConfig(state, config) {
     state.server = config;
-    console.log("setServerConfig", state.server.region)
+    console.log("store:setServerConfig", state.server.region)
   }
 };
 


### PR DESCRIPTION
- 立ち上がり時にサーバーから systemGetConfig でサーバー側の config を取得するようにしました。現時点では region のみです。
- 取得した serverConfig は、$store.state.server にしまっています
- store の getter.stripeRegion でサーバーから取得した region を利用して、region-specific な Stripe のオプションを返すようにしています（ローカルで region を設定するように変更した場合は、ここを変更します）
- Stripe への hidePostalCode オプションはそちらを利用しています。その結果、郵便番号の入力は、us の場合のみ要求されます。