### PR TITLE
ISO 3166 country codes

### DIFF
--- a/functions/src/stripe/utils.ts
+++ b/functions/src/stripe/utils.ts
@@ -3,8 +3,8 @@ import { stripe_regions } from '../common/constant'
 import Stripe from 'stripe'
 
 const locale = functions.config().locale;
-export const region = (locale && locale.region) || "us";
-export const stripe_region = stripe_regions[region] || stripe_regions["us"];
+export const region = (locale && locale.region) || "US";
+export const stripe_region = stripe_regions[region] || stripe_regions["US"];
 
 export const validate_auth = (context: functions.https.CallableContext) => {
   if (!context.auth) {

--- a/src/plugins/constant.js
+++ b/src/plugins/constant.js
@@ -19,17 +19,17 @@ export const order_error = {
 };
 
 export const stripe_regions = {
-  "us": {
+  "US": {
     currency: 'USD',
     multiple: 100,
     hidePostalCode: false
   },
-  "eu": {
+  "EU": {
     currency: 'EUR',
     multiple: 100,
     hidePostalCode: false
   },
-  "jp": {
+  "JP": {
     currency: 'JPY',
     multiple: 1,
     hidePostalCode: true

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -31,7 +31,7 @@ export const getters = {
     return state.user && state.user.name || "";
   },
   stripeRegion: (state) => {
-    return stripe_regions[state.server.region || "us"]
+    return stripe_regions[state.server.region || "US"]
   }
 };
 


### PR DESCRIPTION
ISO3166に従って、region code を大文字にしました（US, JP, EU)。
この方が、language code (en, ja, fr など）とはっきり区別がつくので良いと思います。