### PR TITLE
Hotfix v031 01

### DIFF
--- a/lang/ja.json
+++ b/lang/ja.json
@@ -112,7 +112,7 @@
       "error": "エラー",
       "new_order": "新規注文",
       "validation_ok": "確認済み",
-      "order_placed": "支払い済み",
+      "order_placed": "注文済み",
       "order_accepted": "受付済み",
       "cooking_completed": "料理済み",
       "customer_picked_up": "受け渡し完了",

--- a/src/app/user/OrderPage.vue
+++ b/src/app/user/OrderPage.vue
@@ -86,7 +86,7 @@
             </div>
           </div>
           <div v-else>{{ $t('order.pleasePayAtRestaurant') }}</div>
-          <div class="is-centered" style="text-align: center;">
+          <div v-if="!showPayment" class="is-centered" style="text-align: center;">
             <b-button
               expanded
               :type="showPayment ? '' : 'is-primary'"


### PR DESCRIPTION
1. ステータスの名称を "支払い済み" から "注文済み" に変更
2. レストラン側が課金設定をしてある場合は、支払わずに注文確定することを不可能に