### PR TITLE
Pickup Time

### DIFF
--- a/functions/src/functions/order.ts
+++ b/functions/src/functions/order.ts
@@ -10,7 +10,7 @@ import Order from '../models/Order'
 // This function is called by users to place orders without paying
 export const place = async (db: FirebaseFirestore.Firestore, data: any, context: functions.https.CallableContext) => {
   const uid = utils.validate_auth(context);
-  const { restaurantId, orderId, tip, sendSMS } = data;
+  const { restaurantId, orderId, tip, sendSMS, timeToPickup } = data;
   utils.validate_params({ restaurantId, orderId }) // tip and sendSMS are optinoal
 
   try {
@@ -35,7 +35,7 @@ export const place = async (db: FirebaseFirestore.Firestore, data: any, context:
         totalCharge: order.total + tip,
         tip: roundedTip,
         sendSMS: sendSMS || false,
-        timePlaced: admin.firestore.FieldValue.serverTimestamp()
+        timePlaced: timeToPickup && new admin.firestore.Timestamp(timeToPickup.seconds, timeToPickup.nanoseconds) || admin.firestore.FieldValue.serverTimestamp(),
       })
 
       return { success: true }

--- a/functions/src/stripe/intent.ts
+++ b/functions/src/stripe/intent.ts
@@ -13,7 +13,7 @@ export const create = async (db: FirebaseFirestore.Firestore, data: any, context
   const uid = utils.validate_auth(context);
   const stripe = utils.get_stripe();
 
-  const { orderId, restaurantId, paymentMethodId, tip, sendSMS } = data;
+  const { orderId, restaurantId, paymentMethodId, tip, sendSMS, timeToPickup } = data;
   utils.validate_params({ orderId, restaurantId, paymentMethodId }); // tip and sendSMS are optional
 
   const restaurantData = await utils.get_restaurant(db, restaurantId);
@@ -59,7 +59,7 @@ export const create = async (db: FirebaseFirestore.Firestore, data: any, context
       })
 
       transaction.set(orderRef, {
-        timePlaced: admin.firestore.FieldValue.serverTimestamp(),
+        timePlaced: timeToPickup && new admin.firestore.Timestamp(timeToPickup.seconds, timeToPickup.nanoseconds) || admin.firestore.FieldValue.serverTimestamp(),
         status: order_status.order_placed,
         totalCharge: totalCharge / multiple,
         tip: Math.round(tip * multiple) / multiple,

--- a/src/app/user/Order/TimeToPickup.vue
+++ b/src/app/user/Order/TimeToPickup.vue
@@ -1,7 +1,58 @@
 <template>
   <div>
     <b-field label="TimeToPickup">
-      <p>Foo</p>
+      <b-select v-model="dayIndex">
+        <option v-for="day in availableDays" :value="day.index" :key="day.index">
+          {{ $d(day.date, "short" )}}
+          <span v-if="day.index===0">{{$t('date.today')}}</span>
+        </option>
+      </b-select>
     </b-field>
   </div>
 </template>
+
+<script>
+import { midNight } from "~/plugins/dateUtils.js";
+
+export default {
+  data() {
+    return {
+      dayIndex: 0
+    };
+  },
+  props: {
+    shopInfo: {
+      type: Object,
+      required: true
+    }
+  },
+  mounted() {
+    //console.log(this.shopInfo.businessDay);
+    console.log(this.shopInfo.openTimes);
+    const now = new Date();
+    //console.log(this.availableDays);
+  },
+  computed: {
+    dayOfWeek() {
+      return new Date().getDay();
+    },
+    availableDays() {
+      const today = this.dayOfWeek;
+      return [0, 1, 2, 3, 4, 5, 6]
+        .filter(offset => {
+          return this.isOpen((today + offset) % 7);
+        })
+        .map(offset => {
+          const date = midNight(offset);
+          return { index: offset, date };
+        });
+    }
+  },
+  methods: {
+    isOpen(day) {
+      const key = ((day + 6) % 7) + 1;
+      return this.shopInfo.businessDay[key];
+    }
+  }
+};
+</script>

--- a/src/app/user/Order/TimeToPickup.vue
+++ b/src/app/user/Order/TimeToPickup.vue
@@ -8,6 +8,9 @@
         </option>
       </b-select>
     </b-field>
+    <b-select v-model="timeIndex">
+      <option v-for="time in availableDays[dayIndex].times" :value="time" :key="time">{{ time }}</option>
+    </b-select>
   </div>
 </template>
 
@@ -17,7 +20,8 @@ import { midNight } from "~/plugins/dateUtils.js";
 export default {
   data() {
     return {
-      dayIndex: 0
+      dayIndex: 0,
+      timeIndex: 0
     };
   },
   props: {
@@ -27,10 +31,7 @@ export default {
     }
   },
   mounted() {
-    //console.log(this.shopInfo.businessDay);
-    console.log(this.shopInfo.openTimes);
-    const now = new Date();
-    //console.log(this.availableDays);
+    this.timeIndex = this.availableDays[0].times[0];
   },
   computed: {
     dayOfWeek() {
@@ -44,8 +45,9 @@ export default {
         })
         .map(offset => {
           const date = midNight(offset);
-          //const times = this.shopInfo.openTimes
-          return { index: offset, date };
+          const times = this.openSlots[(today + offset) % 7];
+          console.log(times);
+          return { index: offset, date, times };
         });
     },
     businessDays() {
@@ -54,11 +56,23 @@ export default {
         return this.shopInfo.businessDay[key];
       });
     },
-    openTimes() {
+    openSlots() {
       return [0, 1, 2, 3, 4, 5, 6].map(day => {
         const key = ((day + 6) % 7) + 1;
-        return this.shopInfo.openTimes[key];
+        return this.shopInfo.openTimes[key].reduce((ret, value) => {
+          for (
+            let time = value.start;
+            time < value.end;
+            time += this.timeInterval
+          ) {
+            ret.push(time);
+          }
+          return ret;
+        }, []);
       });
+    },
+    timeInterval() {
+      return 10; // LATER: Make it customizable
     }
   }
 };

--- a/src/app/user/Order/TimeToPickup.vue
+++ b/src/app/user/Order/TimeToPickup.vue
@@ -40,18 +40,25 @@ export default {
       const today = this.dayOfWeek;
       return [0, 1, 2, 3, 4, 5, 6]
         .filter(offset => {
-          return this.isOpen((today + offset) % 7);
+          return this.businessDays[(today + offset) % 7];
         })
         .map(offset => {
           const date = midNight(offset);
+          //const times = this.shopInfo.openTimes
           return { index: offset, date };
         });
-    }
-  },
-  methods: {
-    isOpen(day) {
-      const key = ((day + 6) % 7) + 1;
-      return this.shopInfo.businessDay[key];
+    },
+    businessDays() {
+      return [0, 1, 2, 3, 4, 5, 6].map(day => {
+        const key = ((day + 6) % 7) + 1;
+        return this.shopInfo.businessDay[key];
+      });
+    },
+    openTimes() {
+      return [0, 1, 2, 3, 4, 5, 6].map(day => {
+        const key = ((day + 6) % 7) + 1;
+        return this.shopInfo.openTimes[key];
+      });
     }
   }
 };

--- a/src/app/user/Order/TimeToPickup.vue
+++ b/src/app/user/Order/TimeToPickup.vue
@@ -8,11 +8,11 @@
         </option>
       </b-select>
     </b-field>
-    <b-select v-model="timeIndex">
+    <b-select v-model="time">
       <option
         v-for="time in availableDays[dayIndex].times"
-        :value="time.index"
-        :key="time.index"
+        :value="time.time"
+        :key="time.time"
       >{{ time.display }}</option>
     </b-select>
   </div>
@@ -25,7 +25,7 @@ export default {
   data() {
     return {
       dayIndex: 0,
-      timeIndex: 0
+      time: 0
     };
   },
   props: {
@@ -34,7 +34,9 @@ export default {
       required: true
     }
   },
-  mounted() {},
+  mounted() {
+    this.time = this.availableDays[0].times[0].time;
+  },
   computed: {
     dayOfWeek() {
       return new Date().getDay();
@@ -74,7 +76,7 @@ export default {
             time < value.end;
             time += this.timeInterval
           ) {
-            ret.push({ index: ret.length, time, display: this.num2time(time) });
+            ret.push({ time, display: this.num2time(time) });
           }
           return ret;
         }, []);

--- a/src/app/user/Order/TimeToPickup.vue
+++ b/src/app/user/Order/TimeToPickup.vue
@@ -9,7 +9,11 @@
       </b-select>
     </b-field>
     <b-select v-model="timeIndex">
-      <option v-for="time in availableDays[dayIndex].times" :value="time" :key="time">{{ time }}</option>
+      <option
+        v-for="time in availableDays[dayIndex].times"
+        :value="time.index"
+        :key="time.index"
+      >{{ time.display }}</option>
     </b-select>
   </div>
 </template>
@@ -30,9 +34,7 @@ export default {
       required: true
     }
   },
-  mounted() {
-    this.timeIndex = this.availableDays[0].times[0];
-  },
+  mounted() {},
   computed: {
     dayOfWeek() {
       return new Date().getDay();
@@ -46,7 +48,6 @@ export default {
         .map(offset => {
           const date = midNight(offset);
           const times = this.openSlots[(today + offset) % 7];
-          console.log(times);
           return { index: offset, date, times };
         });
     },
@@ -65,7 +66,7 @@ export default {
             time < value.end;
             time += this.timeInterval
           ) {
-            ret.push(time);
+            ret.push({ index: ret.length, time, display: this.num2time(time) });
           }
           return ret;
         }, []);

--- a/src/app/user/Order/TimeToPickup.vue
+++ b/src/app/user/Order/TimeToPickup.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <b-field label="TimeToPickup">
-      <b-select v-model="dayIndex" @change="handleDayChange">
+      <b-select v-model="dayIndex">
         <option v-for="day in availableDays" :value="day.index" :key="day.index">
           {{ $d(day.date, "short" )}}
           <span v-if="day.index===0">{{$t('date.today')}}</span>
@@ -37,6 +37,14 @@ export default {
   mounted() {
     this.time = this.availableDays[0].times[0].time;
   },
+  watch: {
+    dayIndex(newValue) {
+      this.time = this.availableDays[newValue].times[0].time;
+    },
+    time() {
+      console.log("time changed");
+    }
+  },
   computed: {
     dayOfWeek() {
       return new Date().getDay();
@@ -70,7 +78,6 @@ export default {
       return [0, 1, 2, 3, 4, 5, 6].map(day => {
         const key = ((day + 6) % 7) + 1;
         return this.shopInfo.openTimes[key].reduce((ret, value) => {
-          console.log(day, value.start, value.end);
           for (
             let time = value.start;
             time < value.end;
@@ -90,11 +97,6 @@ export default {
     },
     daysInAdvance() {
       return 4; // LATER: Make it customizable
-    }
-  },
-  methods: {
-    handleDayChange() {
-      console.log("foo");
     }
   }
 };

--- a/src/app/user/Order/TimeToPickup.vue
+++ b/src/app/user/Order/TimeToPickup.vue
@@ -1,0 +1,7 @@
+<template>
+  <div>
+    <b-field label="TimeToPickup">
+      <p>Foo</p>
+    </b-field>
+  </div>
+</template>

--- a/src/app/user/Order/TimeToPickup.vue
+++ b/src/app/user/Order/TimeToPickup.vue
@@ -43,7 +43,7 @@ export default {
     },
     availableDays() {
       const today = this.dayOfWeek;
-      return [0, 1, 2, 3, 4, 5, 6]
+      return Array.from(Array(this.daysInAdvance).keys())
         .filter(offset => {
           return this.businessDays[(today + offset) % 7];
         })
@@ -87,6 +87,9 @@ export default {
     },
     minimumCookTime() {
       return 30; // LATER: Make it customizable
+    },
+    daysInAdvance() {
+      return 4; // LATER: Make it customizable
     }
   }
 };

--- a/src/app/user/Order/TimeToPickup.vue
+++ b/src/app/user/Order/TimeToPickup.vue
@@ -54,7 +54,7 @@ export default {
             const now = new Date();
             const localMin = now.getHours() * 60 + now.getMinutes();
             times = times.filter(time => {
-              return time.time > localMin;
+              return time.time >= localMin + this.minimumCookTime;
             });
           }
           return { index: offset, date, times };

--- a/src/app/user/Order/TimeToPickup.vue
+++ b/src/app/user/Order/TimeToPickup.vue
@@ -101,6 +101,14 @@ export default {
     daysInAdvance() {
       return 4; // LATER: Make it customizable
     }
+  },
+  methods: {
+    timeToPickup() {
+      const date = this.availableDays[this.dayIndex].date;
+      date.setHours(this.time / 60);
+      date.setMinutes(this.time % 60);
+      return date;
+    }
   }
 };
 </script>

--- a/src/app/user/Order/TimeToPickup.vue
+++ b/src/app/user/Order/TimeToPickup.vue
@@ -20,6 +20,7 @@
 
 <script>
 import { midNight } from "~/plugins/dateUtils.js";
+import * as firebase from "firebase/app";
 
 export default {
   data() {
@@ -107,7 +108,8 @@ export default {
       const date = this.availableDays[this.dayIndex].date;
       date.setHours(this.time / 60);
       date.setMinutes(this.time % 60);
-      return date;
+      const ts = firebase.firestore.Timestamp.fromDate(date);
+      return new firebase.firestore.Timestamp(ts.seconds, ts.nanoseconds);
     }
   }
 };

--- a/src/app/user/Order/TimeToPickup.vue
+++ b/src/app/user/Order/TimeToPickup.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <b-field label="TimeToPickup">
-      <b-select v-model="dayIndex">
+      <b-select v-model="dayIndex" @change="handleDayChange">
         <option v-for="day in availableDays" :value="day.index" :key="day.index">
           {{ $d(day.date, "short" )}}
           <span v-if="day.index===0">{{$t('date.today')}}</span>
@@ -47,7 +47,7 @@ export default {
         .filter(offset => {
           return this.businessDays[(today + offset) % 7];
         })
-        .map(offset => {
+        .map((offset, index) => {
           const date = midNight(offset);
           let times = this.openSlots[(today + offset) % 7];
           if (offset === 0) {
@@ -57,7 +57,7 @@ export default {
               return time.time >= localMin + this.minimumCookTime;
             });
           }
-          return { index: offset, date, times };
+          return { index, offset, date, times };
         });
     },
     businessDays() {
@@ -86,10 +86,15 @@ export default {
       return 10; // LATER: Make it customizable
     },
     minimumCookTime() {
-      return 30; // LATER: Make it customizable
+      return 25; // LATER: Make it customizable
     },
     daysInAdvance() {
       return 4; // LATER: Make it customizable
+    }
+  },
+  methods: {
+    handleDayChange() {
+      console.log("foo");
     }
   }
 };

--- a/src/app/user/Order/TimeToPickup.vue
+++ b/src/app/user/Order/TimeToPickup.vue
@@ -55,7 +55,7 @@ export default {
         .filter(offset => {
           return this.businessDays[(today + offset) % 7];
         })
-        .map((offset, index) => {
+        .map(offset => {
           const date = midNight(offset);
           let times = this.openSlots[(today + offset) % 7];
           if (offset === 0) {
@@ -65,7 +65,14 @@ export default {
               return time.time >= localMin + this.minimumCookTime;
             });
           }
-          return { index, offset, date, times };
+          return { offset, date, times };
+        })
+        .filter(day => {
+          return day.times.length > 0;
+        })
+        .map((day, index) => {
+          day.index = index;
+          return day;
         });
     },
     businessDays() {

--- a/src/app/user/Order/TimeToPickup.vue
+++ b/src/app/user/Order/TimeToPickup.vue
@@ -47,7 +47,14 @@ export default {
         })
         .map(offset => {
           const date = midNight(offset);
-          const times = this.openSlots[(today + offset) % 7];
+          let times = this.openSlots[(today + offset) % 7];
+          if (offset === 0) {
+            const now = new Date();
+            const localMin = now.getHours() * 60 + now.getMinutes();
+            times = times.filter(time => {
+              return time.time > localMin;
+            });
+          }
           return { index: offset, date, times };
         });
     },
@@ -61,6 +68,7 @@ export default {
       return [0, 1, 2, 3, 4, 5, 6].map(day => {
         const key = ((day + 6) % 7) + 1;
         return this.shopInfo.openTimes[key].reduce((ret, value) => {
+          console.log(day, value.start, value.end);
           for (
             let time = value.start;
             time < value.end;
@@ -74,6 +82,9 @@ export default {
     },
     timeInterval() {
       return 10; // LATER: Make it customizable
+    },
+    minimumCookTime() {
+      return 30; // LATER: Make it customizable
     }
   }
 };

--- a/src/app/user/Order/TimeToPickup.vue
+++ b/src/app/user/Order/TimeToPickup.vue
@@ -73,15 +73,13 @@ export default {
         });
     },
     businessDays() {
-      return [0, 1, 2, 3, 4, 5, 6].map(day => {
-        const key = ((day + 6) % 7) + 1;
-        return this.shopInfo.businessDay[key];
+      return [7, 1, 2, 3, 4, 5, 6].map(day => {
+        return this.shopInfo.businessDay[day];
       });
     },
     openSlots() {
-      return [0, 1, 2, 3, 4, 5, 6].map(day => {
-        const key = ((day + 6) % 7) + 1;
-        return this.shopInfo.openTimes[key].reduce((ret, value) => {
+      return [7, 1, 2, 3, 4, 5, 6].map(day => {
+        return this.shopInfo.openTimes[day].reduce((ret, value) => {
           for (
             let time = value.start;
             time < value.end;

--- a/src/app/user/Order/TimeToPickup.vue
+++ b/src/app/user/Order/TimeToPickup.vue
@@ -2,9 +2,9 @@
   <div>
     <b-field label="TimeToPickup">
       <b-select v-model="dayIndex">
-        <option v-for="day in availableDays" :value="day.index" :key="day.index">
+        <option v-for="(day, index) in availableDays" :value="index" :key="day.offset">
           {{ $d(day.date, "short" )}}
-          <span v-if="day.index===0">{{$t('date.today')}}</span>
+          <span v-if="day.offset===0">{{$t('date.today')}}</span>
         </option>
       </b-select>
     </b-field>
@@ -69,10 +69,6 @@ export default {
         })
         .filter(day => {
           return day.times.length > 0;
-        })
-        .map((day, index) => {
-          day.index = index;
-          return day;
         });
     },
     businessDays() {

--- a/src/app/user/OrderPage.vue
+++ b/src/app/user/OrderPage.vue
@@ -58,6 +58,8 @@
             >{{$t('order.editItems')}}</b-button>
           </div>
 
+          <time-to-pickup />
+
           <hr class="hr-black" />
           <div v-if="showPayment">
             <h2>{{$t('order.yourPayment')}}</h2>
@@ -113,6 +115,7 @@ import ShopOrnerInfo from "~/app/user/Restaurant/ShopOrnerInfo";
 import OrderInfo from "~/app/user/Order/OrderInfo";
 import ShopInfo from "~/app/user/Restaurant/ShopInfo";
 import StripeCard from "~/app/user/Order/StripeCard";
+import TimeToPickup from "~/app/user/Order/TimeToPickup";
 import NotFound from "~/components/NotFound";
 
 import { db, firestore, functions } from "~/plugins/firebase.js";
@@ -128,6 +131,7 @@ export default {
     OrderInfo,
     ShopInfo,
     StripeCard,
+    TimeToPickup,
     NotFound
   },
   data() {

--- a/src/app/user/OrderPage.vue
+++ b/src/app/user/OrderPage.vue
@@ -287,7 +287,6 @@ export default {
     async handlePayment() {
       const timeToPickup = this.$refs.time.timeToPickup();
       console.log("handlePayment", timeToPickup);
-      return;
 
       this.isPaying = true;
       const {
@@ -304,6 +303,7 @@ export default {
       try {
         const { data } = await stripeCreateIntent({
           paymentMethodId: paymentMethod.id,
+          timeToPickup,
           restaurantId: this.restaurantId(),
           orderId: this.orderId,
           description: `${this.orderName} ${this.shopInfo.restaurantName} ${this.shopInfo.phoneNumber}`,
@@ -319,11 +319,13 @@ export default {
       }
     },
     async handleNoPayment() {
+      const timeToPickup = this.$refs.time.timeToPickup();
       const orderPlace = functions.httpsCallable("orderPlace");
       try {
         this.isPlacing = true;
         const { data } = await orderPlace({
           restaurantId: this.restaurantId(),
+          timeToPickup,
           orderId: this.orderId,
           sendSMS: this.sendSMS,
           tip: this.tip || 0

--- a/src/app/user/OrderPage.vue
+++ b/src/app/user/OrderPage.vue
@@ -58,7 +58,7 @@
             >{{$t('order.editItems')}}</b-button>
           </div>
 
-          <time-to-pickup />
+          <time-to-pickup v-if="shopInfo.businessDay" :shopInfo="shopInfo" />
 
           <hr class="hr-black" />
           <div v-if="showPayment">

--- a/src/app/user/OrderPage.vue
+++ b/src/app/user/OrderPage.vue
@@ -58,7 +58,7 @@
             >{{$t('order.editItems')}}</b-button>
           </div>
 
-          <time-to-pickup v-if="shopInfo.businessDay" :shopInfo="shopInfo" />
+          <time-to-pickup v-if="shopInfo.businessDay" :shopInfo="shopInfo" ref="time" />
 
           <hr class="hr-black" />
           <div v-if="showPayment">
@@ -285,6 +285,10 @@ export default {
       });
     },
     async handlePayment() {
+      const timeToPickup = this.$refs.time.timeToPickup();
+      console.log("handlePayment", timeToPickup);
+      return;
+
       this.isPaying = true;
       const {
         error,

--- a/src/config/default/ownplate-dev.js
+++ b/src/config/default/ownplate-dev.js
@@ -12,5 +12,5 @@ export const ownPlateConfig = {
   siteName: "OwnPlate",
   siteDescription: "Zero Comission Take-out Service",
   releasName: "beta-dev",
-  region: "US",
+  region: "JP",
 };

--- a/src/plugins/dateUtils.js
+++ b/src/plugins/dateUtils.js
@@ -2,6 +2,7 @@ export const midNight = (delta = 0) => {
   const date = new Date();
   date.setHours(0); // local midnight
   date.setMinutes(0);
+  date.setSeconds(0);
   date.setDate(date.getDate() + delta);
   return date;
 };

--- a/src/plugins/utils.js
+++ b/src/plugins/utils.js
@@ -1,6 +1,6 @@
 import Vue from 'vue';
 
-export default ({app}) => {
+export default ({ app }) => {
   Vue.mixin({
     methods: {
       isNull(value) {
@@ -28,18 +28,20 @@ export default ({app}) => {
       },
       num2time(num) {
         let ampm = "AM";
-        if (num > 60 * 12) {
+        if (num >= 60 * 12) {
           ampm = "PM";
-          num = num - 60 * 12;
+          if (num >= 60 * 13) {
+            num = num - 60 * 12;
+          }
         }
         return [
-          String(Math.floor(num/60)).padStart(2, '0'),
+          String(Math.floor(num / 60)).padStart(2, '0'),
           ":",
           String(num % 60).padStart(2, '0'),
           " ",
           ampm].join("");
       },
-      countObj (obj) {
+      countObj(obj) {
         if (Array.isArray(obj)) {
           return obj.reduce((tmp, value) => {
             // nested array
@@ -61,7 +63,7 @@ export default ({app}) => {
           return tmp;
         }, {});
       },
-      copyClipboard: async function(text) {
+      copyClipboard: async function (text) {
         try {
           await this.$copyText(text);
           this.$buefy.toast.open(app.i18n.tc('shopInfo.UrlCopied'));


### PR DESCRIPTION
顧客が注文を受け取る時間を指定できるようにしました。
時間の単位は１０分で、開店から閉店の１０分前までが指定できます。
閉店時でも予約が出来、３日後までの予約が可能です。
現在時刻から最低でも25分必要です。
デフォルトでは、予約可能な時間の先頭のものが選ばれます。

オーダーの表示側にも若干の変更が必要ですが、その変更は次のPRで行います。
「10分単位」「３日後まで」「最低25分」などのパラメータは、後でレストランごとのカスタマイズが出来るように computed props として切り離してあります。