### PR TITLE
WIP: Use hashed lineId

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -111,6 +111,18 @@ service cloud.firestore {
       }
     }
 
+    match /hash/{hashId}{
+      match /records/{eventId} {
+        allow write: if hashing.sha256(request.auth.uid).toHexString() == hashId
+                      && request.resource.data.uid == hashId;
+        allow read: if hashing.sha256(request.auth.uid).toHexString() == hashId;
+        allow write: if hashing.sha256(request.auth.token.line).toHexString() == hashId
+                      && request.resource.data.uid == hashId;
+        allow read: if hashing.sha256(request.auth.token.line).toHexString() == hashId;
+      }
+    }
+
+    // BUGBUG: obsolete
     match /line/{userId}{
       match /records/{eventId} {
         allow write: if request.auth.uid == userId

--- a/firestore.rules
+++ b/firestore.rules
@@ -113,12 +113,12 @@ service cloud.firestore {
 
     match /hash/{hashId}{
       match /records/{eventId} {
-        allow write: if hashing.sha256(request.auth.uid).toHexString() == hashId
+        allow write: if hashing.sha256(request.auth.uid).toHexString().lower() == hashId
                       && request.resource.data.uid == hashId;
-        allow read: if hashing.sha256(request.auth.uid).toHexString() == hashId;
-        allow write: if hashing.sha256(request.auth.token.line).toHexString() == hashId
+        allow read: if hashing.sha256(request.auth.uid).toHexString().lower() == hashId;
+        allow write: if hashing.sha256(request.auth.token.line).toHexString().lower() == hashId
                       && request.resource.data.uid == hashId;
-        allow read: if hashing.sha256(request.auth.token.line).toHexString() == hashId;
+        allow read: if hashing.sha256(request.auth.token.line).toHexString().lower() == hashId;
       }
     }
 

--- a/firestore.rules
+++ b/firestore.rules
@@ -113,9 +113,6 @@ service cloud.firestore {
 
     match /hash/{hashId}{
       match /records/{eventId} {
-        allow write: if hashing.sha256(request.auth.uid).toHexString().lower() == hashId
-                      && request.resource.data.uid == hashId;
-        allow read: if hashing.sha256(request.auth.uid).toHexString().lower() == hashId;
         allow write: if hashing.sha256(request.auth.token.line).toHexString().lower() == hashId
                       && request.resource.data.uid == hashId;
         allow read: if hashing.sha256(request.auth.token.line).toHexString().lower() == hashId;

--- a/functions/src/functions/line.ts
+++ b/functions/src/functions/line.ts
@@ -7,7 +7,19 @@ import * as admin from 'firebase-admin';
 export const isEnabled = !!ownPlateConfig.line;
 
 export const setCustomClaim = async (db: FirebaseFirestore.Firestore, data: any, context: functions.https.CallableContext) => {
-  return { success: true }
+  const uid = utils.validate_auth(context);
+  const isLine = uid.slice(0, 5) === "line:"
+  try {
+    if (isLine) {
+      // This looks redundant, but it simplifies the firebase.rules
+      await admin.auth().setCustomUserClaims(uid, {
+        line: uid
+      })
+    }
+    return { success: isLine }
+  } catch (error) {
+    throw utils.process_error(error)
+  }
 }
 
 export const verifyFriend = async (db: FirebaseFirestore.Firestore, data: any, context: functions.https.CallableContext) => {

--- a/functions/src/functions/trace.ts
+++ b/functions/src/functions/trace.ts
@@ -41,6 +41,14 @@ export const process = async (db: FirebaseFirestore.Firestore, data: any, contex
       event: trace.event,
       restaurantName: restaurant.restaurantName
     });
+
+    // Allows the system to reverse lookup
+    const refProfile = db.doc(`hash/${hash}/system/profile`);
+    const profile = (await refProfile.get()).data();
+    if (!profile) {
+      await refProfile.set({ uid: uidLine })
+    }
+
     return { result: restaurant.restaurantName }
   } catch (error) {
     throw utils.process_error(error)

--- a/functions/src/functions/trace.ts
+++ b/functions/src/functions/trace.ts
@@ -1,5 +1,6 @@
 import * as functions from 'firebase-functions'
 import * as utils from '../lib/utils'
+import * as crypto from "crypto";
 
 export const process = async (db: FirebaseFirestore.Firestore, data: any, context: functions.https.CallableContext) => {
   const uid = utils.validate_auth(context);
@@ -9,7 +10,13 @@ export const process = async (db: FirebaseFirestore.Firestore, data: any, contex
   console.log("**** uid", uid, uidLine);
 
   try {
-    const refRecord = db.doc(`line/${uidLine}/records/${eventId}`);
+    //const refRecord = db.doc(`line/${uidLine}/records/${eventId}`);
+    const hash = crypto
+      .createHash("sha256")
+      .update(uidLine)
+      .digest("hex");
+    const refRecord = db.doc(`hash/${hash}/records/${eventId}`);
+
     const record = (await refRecord.get()).data();
     if (!record) {
       throw new functions.https.HttpsError('invalid-argument', 'No document for the specified eventId.')

--- a/src/app/auth/TrackCallback.vue
+++ b/src/app/auth/TrackCallback.vue
@@ -47,6 +47,11 @@ export default {
           console.log("validation succeded");
           const user = await auth.signInWithCustomToken(data.customToken);
           console.log("signInWithCustomToken", user);
+          const lineSetCustomClaim = functions.httpsCallable(
+            "lineSetCustomClaim"
+          );
+          const result = await lineSetCustomClaim();
+          console.log("result", result);
           if (user) {
             this.$router.replace(`/t/${data.nonce}`);
           }

--- a/src/app/trace/Record.vue
+++ b/src/app/trace/Record.vue
@@ -77,21 +77,16 @@ export default {
   },
   async mounted() {
     console.log("user =", this.user, this.isLineUser);
-    if (this.isLineUser) {
-      console.log("line user", this.user.uid);
-      this.record(this.user.uid);
-    } else {
-      if (this.user) {
-        const { claims } = await this.user.getIdTokenResult(true);
-        if (claims.line) {
-          console.log("***** DEBUG *****", claims.line);
-          this.record(claims.line);
-          return;
-        }
+    if (this.user) {
+      const { claims } = await this.user.getIdTokenResult(true);
+      if (claims.line) {
+        console.log("***** DEBUG *****", claims.line);
+        this.record(claims.line);
+        return;
       }
-      if (this.traceId) {
-        location.href = this.lineAuth;
-      }
+    }
+    if (this.traceId) {
+      location.href = this.lineAuth;
     }
   },
   destroyed() {

--- a/src/app/trace/Record.vue
+++ b/src/app/trace/Record.vue
@@ -23,6 +23,7 @@
 <script>
 import { ownPlateConfig } from "@/config/project";
 import { db, firestore, functions } from "~/plugins/firebase.js";
+import * as crypto from "crypto";
 
 export default {
   data() {
@@ -34,12 +35,18 @@ export default {
   },
   methods: {
     async record(lineUid) {
-      const refRecords = db.collection(`line/${lineUid}/records`);
+      const hash = crypto
+        .createHash("sha256")
+        .update(lineUid)
+        .digest("hex");
+      console.log("*********", hash);
+
+      const refRecords = db.collection(`hash/${hash}/records`);
       if (this.traceId) {
         try {
           const doc = await refRecords.add({
             traceId: this.traceId,
-            uid: lineUid,
+            uid: hash,
             timeCreated: firestore.FieldValue.serverTimestamp(),
             processed: false
           });


### PR DESCRIPTION
COVID-19 feature
- 入店・退店レコードをしまう場所を /hash に移しました（/line から）
- /hash 以下にしまう時に、line-uid を sha256 でハッシュ化したものを使うようにしました
- LINE のみでログインしたユーザーの場合でも custome claims に line=line-uid をセットするようにしました（firebase.rules がシンプルで済みます） 
- お店の人用の匿名リスト表示は次のPRで実装します。
- firebase.rules に /line/{userId} ルールが残っていますが、これは次のPRで消します。