### PR TITLE
COVID-19, ENTER/LEAVE pairing

### DIFF
--- a/functions/src/functions/trace.ts
+++ b/functions/src/functions/trace.ts
@@ -50,11 +50,13 @@ export const process = async (db: FirebaseFirestore.Firestore, data: any, contex
       if (records.length === 2) {
         const lastDoc = records[1];
         const lastRecord = lastDoc.data();
+        const duration = record.timeCreated.seconds - lastRecord.timeCreated.seconds;
         if (lastRecord.restaurantId === trace.restaurantId && lastRecord.event === "enter") {
           processed = true;
           await db.runTransaction(async tx => {
             tx.update(lastDoc.ref, {
               timeLeft: record.timeCreated,
+              duration,
               processed
             })
             tx.update(refRecord, {

--- a/functions/src/functions/trace.ts
+++ b/functions/src/functions/trace.ts
@@ -51,7 +51,7 @@ export const process = async (db: FirebaseFirestore.Firestore, data: any, contex
         const lastDoc = records[1];
         const lastRecord = lastDoc.data();
         const duration = record.timeCreated.seconds - lastRecord.timeCreated.seconds;
-        if (lastRecord.restaurantId === trace.restaurantId && lastRecord.event === "enter") {
+        if (lastRecord.restaurantId === trace.restaurantId && lastRecord.event === "enter" && duration < 12 * 3600) {
           processed = true;
           await db.runTransaction(async tx => {
             tx.update(lastDoc.ref, {

--- a/src/app/trace/Record.vue
+++ b/src/app/trace/Record.vue
@@ -12,6 +12,7 @@
           <div v-for="record in records" :key="record.id">
             <span>{{record.timeCreated.toLocaleString()}}</span>
             <span>{{$t('trace.' + record.event)}}</span>
+            <span>{{record.processed ? "*" : " "}}</span>
             <span>{{record.restaurantName}}</span>
           </div>
         </div>

--- a/src/app/trace/Record.vue
+++ b/src/app/trace/Record.vue
@@ -40,7 +40,7 @@ export default {
         .createHash("sha256")
         .update(lineUid)
         .digest("hex");
-      console.log("*********", hash);
+      //console.log("*********", hash);
 
       const refRecords = db.collection(`hash/${hash}/records`);
       if (this.traceId) {
@@ -51,7 +51,7 @@ export default {
             timeCreated: firestore.FieldValue.serverTimestamp(),
             processed: false
           });
-          console.log("recorded as", doc.id);
+          //console.log("recorded as", doc.id);
           this.success = true;
 
           const traceProcess = functions.httpsCallable("traceProcess");
@@ -71,17 +71,17 @@ export default {
               record.timeCreated = record.timeCreated.toDate();
               return record;
             });
-            console.log("snapshot", this.records);
+            //console.log("snapshot", this.records);
           });
       }
     }
   },
   async mounted() {
-    console.log("user =", this.user, this.isLineUser);
+    //console.log("user =", this.user, this.isLineUser);
     if (this.user) {
       const { claims } = await this.user.getIdTokenResult(true);
       if (claims.line) {
-        console.log("***** DEBUG *****", claims.line);
+        //console.log("***** DEBUG *****", claims.line);
         this.record(claims.line);
         return;
       }


### PR DESCRIPTION
退店のイベントが起こった時に、ペアとなる入店情報とのペアリングを行う処理です。これにより、感染者との同時に店にいたかどうかをQueryで調べることが可能になります。ペアリングが成功すると、entry 側に timeLeft が追加され、両方のイベントが processed = true （処理済み）になります。

ペアリングが出来ない場合は、別途、後処理が出来る様に processed=false のままにしてあります。