### PR TITLE
Add "word-break: break-all;" to all <div> and <span>

### DIFF
--- a/src/assets/scss/ownplate.scss
+++ b/src/assets/scss/ownplate.scss
@@ -1,3 +1,8 @@
+div,
+span {
+  word-break: break-all;
+}
+
 // OwnPlate Colors
 $op-colors: (
   test: #ff0000,

--- a/src/assets/scss/ownplate.scss
+++ b/src/assets/scss/ownplate.scss
@@ -1,6 +1,6 @@
 div,
 span {
-  overflow-wrap: anywhere;
+  word-break: break-word;
 }
 
 // OwnPlate Colors

--- a/src/assets/scss/ownplate.scss
+++ b/src/assets/scss/ownplate.scss
@@ -1,6 +1,6 @@
 div,
 span {
-  word-break: break-all;
+  overflow-wrap: anywhere;
 }
 
 // OwnPlate Colors


### PR DESCRIPTION
スペースなしの長い英数字文字列によるレイアウト崩れを解消します。