### PR TITLE
Stripe customer

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -34,4 +34,6 @@ exportIfNeeded("stripeCreateIntent", "stripe/stripeCreateIntent", exports);
 exportIfNeeded("stripeConfirmIntent", "stripe/stripeConfirmIntent", exports);
 exportIfNeeded("stripeCancelIntent", "stripe/stripeCancelIntent", exports);
 
+exportIfNeeded("stripeUpdateCustomer", "stripe/stripeUpdateCustomer", exports);
+
 exportIfNeeded("imageProcessing", "image/imageProcessing", exports);

--- a/functions/src/stripe/customer.ts
+++ b/functions/src/stripe/customer.ts
@@ -21,4 +21,5 @@ export const createCustomer = async (db: FirebaseFirestore.Firestore, uid: strin
 }
 
 export const update = async (db: FirebaseFirestore.Firestore, data: any, context: functions.https.CallableContext) => {
+  return { result: true }
 }

--- a/functions/src/stripe/customer.ts
+++ b/functions/src/stripe/customer.ts
@@ -1,0 +1,20 @@
+import * as utils from '../lib/utils'
+
+export const createCustomer = async (db: FirebaseFirestore.Firestore, uid: string, phoneNumber: string) => {
+  const stripe = utils.get_stripe();
+  await db.runTransaction(async (tr) => {
+    const refStripe = db.doc(`/users/${uid}/system/stripe`)
+    const stripeInfo = (await tr.get(refStripe)).data();
+
+    // Create a stripe customer if we haven't created yet
+    if (!stripeInfo) {
+      const customer = await stripe.customers.create({
+        description: phoneNumber,
+        metadata: { uid, phoneNumber }
+      })
+      tr.set(refStripe, {
+        customerId: customer.id
+      })
+    }
+  });
+}

--- a/functions/src/stripe/customer.ts
+++ b/functions/src/stripe/customer.ts
@@ -1,3 +1,4 @@
+import * as functions from 'firebase-functions'
 import * as utils from '../lib/utils'
 
 export const createCustomer = async (db: FirebaseFirestore.Firestore, uid: string, phoneNumber: string) => {
@@ -17,4 +18,7 @@ export const createCustomer = async (db: FirebaseFirestore.Firestore, uid: strin
       })
     }
   });
+}
+
+export const update = async (db: FirebaseFirestore.Firestore, data: any, context: functions.https.CallableContext) => {
 }

--- a/functions/src/wrappers/stripe/stripeUpdateCustomer.ts
+++ b/functions/src/wrappers/stripe/stripeUpdateCustomer.ts
@@ -1,0 +1,10 @@
+import * as functions from 'firebase-functions';
+import * as admin from 'firebase-admin';
+
+import * as StripeCustomer from '../..//stripe/customer'
+
+const db = admin.firestore();
+
+export default functions.https.onCall(async (data, context) => {
+  return await StripeCustomer.update(db, data, context);
+});


### PR DESCRIPTION
これはユーザーのカードを覚えるための準備です。
1. 最初にオーダーが作られた時に、stripe 上に customer を作ります（uid と phoneNumber をメタデータとしてセットします）。
2. stripeUpdateCustomer のスケルトンを作りました（次のPRで実装します）。
3. 別件ですが、wasOrderCreated2 のトランザクションにバグがあったので修正しました。