### PR TITLE
Stripe: Reuse Credit Card

### DIFF
--- a/functions/src/functions/account.ts
+++ b/functions/src/functions/account.ts
@@ -30,8 +30,11 @@ export const deleteAccount = async (db: FirebaseFirestore.Firestore, data: any, 
 
     const refUser = db.doc(`/users/${uid}`);
     const refSystem = refUser.collection("system");
+    const refReadonly = refUser.collection("readonly");
     const refPrivate = refUser.collection("private");
     await refSystem.doc("line").delete();
+    await refSystem.doc("stripe").delete();
+    await refReadonly.doc("stripe").delete();
     await refPrivate.doc("line").delete();
     await refPrivate.doc("profile").delete();
     await refUser.delete();

--- a/functions/src/stripe/customer.ts
+++ b/functions/src/stripe/customer.ts
@@ -33,7 +33,9 @@ export const update = async (db: FirebaseFirestore.Firestore, data: any, context
     const token = await stripe.tokens.retrieve(tokenId);
     const card = {
       last4: token.card?.last4,
-      brand: token.card?.brand
+      brand: token.card?.brand,
+      exp_month: token.card?.exp_month,
+      exp_year: token.card?.exp_year
     }
     console.log("***token", token);
     await db.runTransaction(async (tr) => {

--- a/functions/src/stripe/customer.ts
+++ b/functions/src/stripe/customer.ts
@@ -22,14 +22,16 @@ export const createCustomer = async (db: FirebaseFirestore.Firestore, uid: strin
 
 export const update = async (db: FirebaseFirestore.Firestore, data: any, context: functions.https.CallableContext) => {
   const uid = utils.validate_auth(context);
-  const { token } = data;
-  utils.validate_params({ token });
+  const { tokenId } = data;
+  utils.validate_params({ tokenId });
   const stripe = utils.get_stripe();
 
   const refStripe = db.doc(`/users/${uid}/system/stripe`)
 
   const result = { result: {} }
   try {
+    const token = await stripe.tokens.retrieve(tokenId);
+    console.log("***token", token);
     await db.runTransaction(async (tr) => {
       const stripeInfo = (await tr.get(refStripe)).data();
       if (!stripeInfo) {
@@ -37,7 +39,7 @@ export const update = async (db: FirebaseFirestore.Firestore, data: any, context
       }
 
       result.result = await stripe.customers.update(stripeInfo.customerId, {
-        source: token
+        source: tokenId
       })
     });
 

--- a/functions/src/stripe/customer.ts
+++ b/functions/src/stripe/customer.ts
@@ -26,17 +26,25 @@ export const update = async (db: FirebaseFirestore.Firestore, data: any, context
   utils.validate_params({ tokenId });
   const stripe = utils.get_stripe();
 
-  const refStripe = db.doc(`/users/${uid}/system/stripe`)
+  const refStripeSystem = db.doc(`/users/${uid}/system/stripe`)
+  const refStripeReadOnly = db.doc(`/users/${uid}/readonly/stripe`)
 
   const result = { result: {} }
   try {
     const token = await stripe.tokens.retrieve(tokenId);
+    const card = {
+      last4: token.card?.last4,
+      brand: token.card?.brand
+    }
     console.log("***token", token);
     await db.runTransaction(async (tr) => {
-      const stripeInfo = (await tr.get(refStripe)).data();
+      const stripeInfo = (await tr.get(refStripeSystem)).data();
       if (!stripeInfo) {
         throw new functions.https.HttpsError('invalid-argument', 'This user does not have a stripe customer.')
       }
+      tr.set(refStripeReadOnly, {
+        card
+      }, { merge: true })
 
       result.result = await stripe.customers.update(stripeInfo.customerId, {
         source: tokenId

--- a/functions/src/stripe/customer.ts
+++ b/functions/src/stripe/customer.ts
@@ -29,7 +29,6 @@ export const update = async (db: FirebaseFirestore.Firestore, data: any, context
   const refStripeSystem = db.doc(`/users/${uid}/system/stripe`)
   const refStripeReadOnly = db.doc(`/users/${uid}/readonly/stripe`)
 
-  const result = { result: {} }
   try {
     const token = await stripe.tokens.retrieve(tokenId);
     const card = {
@@ -46,12 +45,12 @@ export const update = async (db: FirebaseFirestore.Firestore, data: any, context
         card
       }, { merge: true })
 
-      result.result = await stripe.customers.update(stripeInfo.customerId, {
+      await stripe.customers.update(stripeInfo.customerId, {
         source: tokenId
       })
     });
 
-    return result
+    return { success: true }
   } catch (error) {
     throw utils.process_error(error)
   }

--- a/functions/src/stripe/intent.ts
+++ b/functions/src/stripe/intent.ts
@@ -47,6 +47,7 @@ export const create = async (db: FirebaseFirestore.Firestore, data: any, context
       } as Stripe.PaymentIntentCreateParams
 
       if (paymentMethodId) {
+        // This code is obsolete, but keep it for a while in case we need it.
         request.payment_method = paymentMethodId
       } else {
         // If no paymentMethodId, we expect that there is a customer Id associated with a token

--- a/src/app/user/Order/StripeCard.vue
+++ b/src/app/user/Order/StripeCard.vue
@@ -51,9 +51,10 @@ export default {
     async createToken() {
       if (!this.useStoredCard) {
         const { token } = await this.stripe.createToken(this.cardElement);
+        const tokenId = token.id + this.forcedError("token");
         //console.log("***toke", token, token.card.last4);
-        const { data } = await stripeUpdateCustomer({ tokenId: token.id });
-        console.log("stripeUpdateCustomer", data);
+        const { data } = await stripeUpdateCustomer({ tokenId });
+        console.log("stripeUpdateCustomer", data, tokenId);
       }
     },
     configureStripe() {

--- a/src/app/user/Order/StripeCard.vue
+++ b/src/app/user/Order/StripeCard.vue
@@ -31,8 +31,8 @@ export default {
   methods: {
     async createToken() {
       const { token } = await this.stripe.createToken(this.cardElement);
-      console.log("***toke", token);
-      const result = await stripeUpdateCustomer({ token: token.id });
+      console.log("***toke", token, token.card.last4);
+      const result = await stripeUpdateCustomer({ tokenId: token.id });
       console.log("createToken", result);
     },
     async createPaymentMethod() {

--- a/src/app/user/Order/StripeCard.vue
+++ b/src/app/user/Order/StripeCard.vue
@@ -1,6 +1,11 @@
 <template>
-  <div class="bg-surface r-8 d-low m-t-8 p-l-16 p-r-16 p-t-16 p-b-16">
-    <div id="card-element"></div>
+  <div>
+    <div v-if="storedCard">
+      <p>{{storedCard.last4}}</p>
+    </div>
+    <div v-else class="bg-surface r-8 d-low m-t-8 p-l-16 p-r-16 p-t-16 p-b-16">
+      <div id="card-element"></div>
+    </div>
   </div>
 </template>
 
@@ -9,24 +14,15 @@ import { getStripeInstance, stripeUpdateCustomer } from "~/plugins/stripe.js";
 import { functions } from "~/plugins/firebase.js";
 
 export default {
-  props: ["stripeAccount"],
   data() {
     return {
-      stripe: {}, //getStripeInstance(this.stripeAccount),
+      stripe: getStripeInstance(),
+      storedCard: null,
       cardElement: {}
     };
   },
   mounted() {
-    if (this.stripeAccount) {
-      this.stripe = getStripeInstance(/*this.stripeAccount*/);
-      this.configureStripe();
-    }
-  },
-  watch: {
-    stripeAccount: function(newVal, oldVal) {
-      this.stripe = getStripeInstance(/*newVal*/);
-      this.configureStripe();
-    }
+    this.configureStripe();
   },
   methods: {
     async createToken() {
@@ -34,13 +30,6 @@ export default {
       console.log("***toke", token, token.card.last4);
       const result = await stripeUpdateCustomer({ tokenId: token.id });
       console.log("createToken", result);
-    },
-    async createPaymentMethod() {
-      const payload = await this.stripe.createPaymentMethod({
-        type: "card",
-        card: this.cardElement
-      });
-      return payload;
     },
     configureStripe() {
       const elements = this.stripe.elements();

--- a/src/app/user/Order/StripeCard.vue
+++ b/src/app/user/Order/StripeCard.vue
@@ -6,6 +6,7 @@
 
 <script>
 import { getStripeInstance } from "~/plugins/stripe.js";
+import { functions } from "~/plugins/firebase.js";
 
 export default {
   props: ["stripeAccount"],
@@ -17,18 +18,26 @@ export default {
   },
   mounted() {
     if (this.stripeAccount) {
-      this.stripe = getStripeInstance(this.stripeAccount);
+      this.stripe = getStripeInstance(/*this.stripeAccount*/);
       this.configureStripe();
     }
   },
   watch: {
     stripeAccount: function(newVal, oldVal) {
-      this.stripe = getStripeInstance(newVal);
+      this.stripe = getStripeInstance(/*newVal*/);
       this.configureStripe();
     }
   },
   methods: {
     async createPaymentMethod() {
+      const { token } = await this.stripe.createToken(this.cardElement);
+      console.log("****Token", token.id);
+      const stripeUpdateCustomer = functions.httpsCallable(
+        "stripeUpdateCustomer"
+      );
+      const result = await stripeUpdateCustomer({ token: token.id });
+      console.log("****Result", result);
+
       const payload = await this.stripe.createPaymentMethod({
         type: "card",
         card: this.cardElement

--- a/src/app/user/Order/StripeCard.vue
+++ b/src/app/user/Order/StripeCard.vue
@@ -5,7 +5,7 @@
 </template>
 
 <script>
-import { getStripeInstance } from "~/plugins/stripe.js";
+import { getStripeInstance, stripeUpdateCustomer } from "~/plugins/stripe.js";
 import { functions } from "~/plugins/firebase.js";
 
 export default {
@@ -29,15 +29,13 @@ export default {
     }
   },
   methods: {
-    async createPaymentMethod() {
+    async createToken() {
       const { token } = await this.stripe.createToken(this.cardElement);
-      console.log("****Token", token.id);
-      const stripeUpdateCustomer = functions.httpsCallable(
-        "stripeUpdateCustomer"
-      );
+      console.log("***toke", token);
       const result = await stripeUpdateCustomer({ token: token.id });
-      console.log("****Result", result);
-
+      console.log("createToken", result);
+    },
+    async createPaymentMethod() {
       const payload = await this.stripe.createPaymentMethod({
         type: "card",
         card: this.cardElement

--- a/src/app/user/Order/StripeCard.vue
+++ b/src/app/user/Order/StripeCard.vue
@@ -2,9 +2,8 @@
   <div>
     <div v-if="storedCard" class="m-t-16 m-l-16">
       <b-checkbox v-model="useStoredCard">
-        <span>{{"Use Stored Card:"}}</span>
         <span>{{storedCard.brand}}</span>
-        <span>{{storedCard.last4}}</span>
+        <span>**** **** **** {{storedCard.last4}}</span>
       </b-checkbox>
     </div>
     <div v-show="!useStoredCard" class="bg-surface r-8 d-low m-t-8 p-l-16 p-r-16 p-t-16 p-b-16">

--- a/src/app/user/Order/StripeCard.vue
+++ b/src/app/user/Order/StripeCard.vue
@@ -31,7 +31,6 @@ export default {
     const stripeInfo = (
       await db.doc(`/users/${this.user.uid}/readonly/stripe`).get()
     ).data();
-    console.log("***mounted", stripeInfo);
     if (stripeInfo && stripeInfo.card) {
       this.storedCard = stripeInfo.card;
       this.useStoredCard = true;
@@ -52,9 +51,9 @@ export default {
     async createToken() {
       if (!this.useStoredCard) {
         const { token } = await this.stripe.createToken(this.cardElement);
-        console.log("***toke", token, token.card.last4);
-        const result = await stripeUpdateCustomer({ tokenId: token.id });
-        console.log("createToken", result);
+        //console.log("***toke", token, token.card.last4);
+        const { data } = await stripeUpdateCustomer({ tokenId: token.id });
+        console.log("stripeUpdateCustomer", data);
       }
     },
     configureStripe() {

--- a/src/app/user/OrderPage.vue
+++ b/src/app/user/OrderPage.vue
@@ -199,11 +199,7 @@
 
                 <!-- Pay Online -->
                 <div v-if="showPayment">
-                  <stripe-card
-                    :stripe-account="this.stripeAccount"
-                    @change="handleCardStateChange"
-                    ref="stripe"
-                  ></stripe-card>
+                  <stripe-card @change="handleCardStateChange" ref="stripe"></stripe-card>
                   <!-- <credit-card-input></credit-card-input> -->
                   <!-- Pay Button -->
                   <div class="align-center m-t-24">

--- a/src/app/user/OrderPage.vue
+++ b/src/app/user/OrderPage.vue
@@ -556,7 +556,7 @@ export default {
         }
 
         const { data } = await stripeCreateIntent({
-          paymentMethodId: "token", // paymentMethod.id,
+          //paymentMethodId: paymentMethod.id,
           timeToPickup,
           restaurantId: this.restaurantId() + this.forcedError("intent"),
           orderId: this.orderId,

--- a/src/app/user/OrderPage.vue
+++ b/src/app/user/OrderPage.vue
@@ -545,6 +545,7 @@ export default {
 
       this.isPaying = true;
       try {
+        /*
         const {
           error,
           paymentMethod
@@ -554,7 +555,8 @@ export default {
           this.isPaying = false;
           throw error;
         }
-
+        */
+        await this.$refs.stripe.createToken();
         const { data } = await stripeCreateIntent({
           //paymentMethodId: paymentMethod.id,
           timeToPickup,

--- a/src/app/user/OrderPage.vue
+++ b/src/app/user/OrderPage.vue
@@ -556,7 +556,7 @@ export default {
         }
 
         const { data } = await stripeCreateIntent({
-          paymentMethodId: paymentMethod.id,
+          paymentMethodId: "token", // paymentMethod.id,
           timeToPickup,
           restaurantId: this.restaurantId() + this.forcedError("intent"),
           orderId: this.orderId,

--- a/src/app/user/OrderPage.vue
+++ b/src/app/user/OrderPage.vue
@@ -470,24 +470,24 @@ export default {
         .doc(`restaurants/${this.restaurantId()}/orders/${this.orderId}`)
         .onSnapshot(
           order => {
-            console.log("CALLSNAPSHOT");
+            //console.log("CALLSNAPSHOT");
             const order_data = order.exists ? order.data() : {};
-            console.log(order_data);
+            //console.log(order_data);
             if (
               this.user.uid === order_data.uid ||
               this.$store.getters.isSuperAdmin
             ) {
-              console.log("UPDATE");
+              //console.log("UPDATE");
               this.orderInfo = order_data;
             } else if (!this.isDeleting) {
-              console.log("NOTUPDATE");
+              //console.log("NOTUPDATE");
               this.notFound = true;
             }
           },
           error => {
             // Because of the firestore.rules, it causes "insufficient permissions"
             // if the order does not exist.
-            console.log(error);
+            console.error(error.message);
             this.notFound = true;
           }
         );
@@ -537,7 +537,7 @@ export default {
     },
     async handlePayment() {
       const timeToPickup = this.$refs.time.timeToPickup();
-      console.log("handlePayment", timeToPickup);
+      //console.log("handlePayment", timeToPickup);
 
       this.isPaying = true;
       try {
@@ -550,7 +550,7 @@ export default {
           sendSMS: this.sendSMS,
           tip: this.tip || 0
         });
-        console.log("create", data);
+        console.log("createIntent", data);
         window.scrollTo(0, 0);
       } catch (error) {
         console.error(error.message, error.details);

--- a/src/app/user/OrderPage.vue
+++ b/src/app/user/OrderPage.vue
@@ -541,20 +541,8 @@ export default {
 
       this.isPaying = true;
       try {
-        /*
-        const {
-          error,
-          paymentMethod
-        } = await this.$refs.stripe.createPaymentMethod();
-
-        if (error) {
-          this.isPaying = false;
-          throw error;
-        }
-        */
         await this.$refs.stripe.createToken();
         const { data } = await stripeCreateIntent({
-          //paymentMethodId: paymentMethod.id,
           timeToPickup,
           restaurantId: this.restaurantId() + this.forcedError("intent"),
           orderId: this.orderId,

--- a/src/plugins/stripe.js
+++ b/src/plugins/stripe.js
@@ -2,9 +2,12 @@ import { functions } from "~/plugins/firebase"
 
 export const getStripeInstance = (stripeAccount) => {
   const stripeAPIToken = process.env.STRIPE_API_KEY;
-  return Stripe(stripeAPIToken, {
-    stripeAccount: stripeAccount
-  });
+  if (stripeAccount) {
+    return Stripe(stripeAPIToken, {
+      stripeAccount
+    });
+  }
+  return Stripe(stripeAPIToken);
 }
 
 export const stripeCreateIntent = functions.httpsCallable("stripeCreateIntent");

--- a/src/plugins/stripe.js
+++ b/src/plugins/stripe.js
@@ -17,3 +17,5 @@ export const stripeCancelIntent
   = functions.httpsCallable("stripeCancelIntent");
 export const stripeConnect = functions.httpsCallable("stripeConnect");
 export const stripeDisconnect = functions.httpsCallable("stripeDisconnect");
+export const stripeUpdateCustomer = functions.httpsCallable("stripeUpdateCustomer");
+


### PR DESCRIPTION
クレジットカード番号を記憶して再利用出来るようにしました。
- stripe 側に customer を作り、そこに記憶させています
- その時に、brand, last4, exp_month/year だけを /users/{mid}/readonly/stripe にしまっています
- ２度目以降は、brand + last4 を表示して、デフォルトではそちらを使います
