### PR TITLE
Add News List and Article templates.

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -289,6 +289,11 @@
     "welcomeMessage": "Welcome to OwnPlate",
     "userManual": "User Manual",
     "suportPage": "Support",
+    "news": {
+      "title": "News",
+      "newsTop": "News Top",
+      "adminTop": "Admin Top"
+    },
     "hidePayment": "Payment feature is coming soon. Please stay tuned.",
     "pleaseSignIn": "Sign In (for Restaurant)",
     "registration": "Registration (for Restaurant)",

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -289,6 +289,11 @@
     "welcomeMessage": "いらっしゃいませ",
     "userManual": "使い方説明",
     "suportPage": "お問い合わせ",
+    "news": {
+      "title": "お知らせ",
+      "newsTop": "お知らせ一覧",
+      "adminTop": "管理画面"
+    },
     "hidePayment": "課金の仕組みはまもなく提供される予定です。少々お待ちください。",
     "pleaseSignIn": "サインインしてください（飲食店向け）",
     "registration": "登録してください（飲食店向け）",

--- a/src/app/admin/Index.vue
+++ b/src/app/admin/Index.vue
@@ -59,14 +59,14 @@
             style="border: 2px solid rgba(0,0,0,0.1); "
           >
             <div class="cols">
-              <div class="t-subtitle2 c-text-black-disabled">お知らせ:</div>
+              <div class="t-subtitle2 c-text-black-disabled">2020.06.05</div>
               <div class="t-subtitle2 c-primary flex-1 align-right">
-                <nuxt-link target="_blank" :to="'/admin/news/'">全て見る</nuxt-link>
+                <nuxt-link :to="'/admin/news/'">{{$t('admin.news.newsTop')}}</nuxt-link>
               </div>
             </div>
             <!-- News Item -->
             <div class="t-subtitle1 c-primary m-t-4">
-              <nuxt-link target="_blank" :to="'/admin/news/' + newsId">2020.06.05: v0.5.1をリリースしました。</nuxt-link>
+              <nuxt-link :to="'/admin/news/' + newsId">v0.5.1をリリースしました。</nuxt-link>
             </div>
           </div>
         </div>

--- a/src/app/admin/News/Article.vue
+++ b/src/app/admin/News/Article.vue
@@ -1,5 +1,126 @@
 <template>
   <div>
-    hello
+    <!-- Article Header Area -->
+    <div class="columns is-gapless">
+      <!-- Left Gap -->
+      <div class="column is-narrow w-24"></div>
+      <!-- Center Column -->
+      <div class="column">
+        <div class="m-l-24 m-r-24 m-t-24">
+          <!-- Back to Admin Top -->
+          <nuxt-link :to="'/admin/restaurants'">
+            <div class="op-button-pill bg-form m-r-16">
+              <i class="material-icons c-primary s-18">home</i>
+              <span class="c-primary t-button">{{$t("admin.news.adminTop")}}</span>
+            </div>
+          </nuxt-link>
+
+          <!-- Back to News Top -->
+          <nuxt-link :to="'/admin/news'">
+            <div class="op-button-pill bg-form">
+              <i class="material-icons c-primary s-18">list</i>
+              <span class="c-primary t-button">{{$t("admin.news.newsTop")}}</span>
+            </div>
+          </nuxt-link>
+        </div>
+      </div>
+      <!-- Right Gap -->
+      <div class="column is-narrow w-24"></div>
+    </div>
+
+    <!-- Article Body Area -->
+    <div class="columns is-gapless">
+      <!-- Left Gap -->
+      <div class="column is-narrow w-24"></div>
+      <!-- Center Column -->
+      <div class="column">
+        <div class="columns is-gaplress">
+          <div class="column is-three-fifths is-offset-one-fifth">
+            <div class="m-l-24 m-r-24">
+              <div class="m-t-24">
+                <!-- Title -->
+                <div class="t-h6 c-text-black-disabled">v0.5.1をリリースしました。</div>
+                <div class="t-subtitle1 c-text-black-disabled m-t-8">2020.06.04</div>
+
+                <!-- Body -->
+                <div
+                  class="article-p m-t-24 t-body1 c-text-black-high"
+                >Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse a erat et nulla elementum elementum. Suspendisse magna sem, cursus sed viverra et, suscipit sed arcu. Etiam suscipit elementum nibh at porta. Phasellus sit amet ante venenatis, facilisis tortor non, pellentesque diam. Aliquam ac rhoncus dui. Aenean scelerisque augue nec consequat elementum. Sed consectetur ut arcu sed ultricies. Sed ac cursus odio. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Praesent et imperdiet magna. Nulla lobortis risus id laoreet sodales. Nulla facilisi. Pellentesque at tempus dui. Ut hendrerit arcu ligula, eget tincidunt tortor dapibus ut. Pellentesque volutpat pharetra orci nec ullamcorper.</div>
+
+                <div
+                  class="article-p m-t-24 t-body1 c-text-black-high"
+                >シンギュラリティ・ソサエティは、技術の進歩により大きく変わろうとしている世の中に向けた活動をするNPO（非営利型一般社団法人）です。 「おもちかえり.com」は、Firebase と Vue という技術を使って作られています。</div>
+
+                <div class="article-list m-t-24">
+                  <ul>
+                    <li>
+                      ユーザ系
+                      <ul>
+                        <li>プロフィールページに「注文履歴」「サインアウト」「飲食店としてサインイン」のリンクを追加。</li>
+                        <li>プロフィールページから友達設定をした直後に表示がアップデートされない問題を解決。</li>
+                        <li>プロフィールページに「アカウント削除」を追加。</li>
+                        <li>LINEとの連携済みの人に連携ボタンが表示されてしまうバグを修正。</li>
+                        <li>入店・退店記録のページで、undefined になってしまうバグを修正。</li>
+                        <li>オーダーページで、ログインしていない状態で見たときにログイン画面を出すように修正。</li>
+                        <li>クレジットカード番号をstripe側に記録しておき、２度目からは入力しなくて良いように変更。</li>
+                        <li>特定商取引のリンク追加。</li>
+                        <li>心付けのオプションとして５％を追加。</li>
+                        <li>CVCの説明を追加。</li>
+                      </ul>
+                    </li>
+                    <li>
+                      管理系
+                      <ul>
+                        <li>自分の店への入店・退店情報を見ることが出来るようにしました（匿名です）。</li>
+                        <li>「受け取り時の支払い」を許すかどうかを指定できるようにしました。</li>
+                        <li>PickUpの時間を変更可能に。</li>
+                        <li>特定商取引の表記の為に、代表者氏名の入力を必須に。</li>
+                        <li>オーダーリストページに、「音テスト」ボタンの追加。</li>
+                      </ul>
+                    </li>
+                    <li>
+                      共通
+                      <ul>
+                        <li>ホームページから、飲食店向けマニュアル、お客様向けマニュアルへのリンクを追加。</li>
+                        <li>メニューにプロフィールページへのリンクを追加。</li>
+                        <li>メニューから「サインアウト」「注文履歴」の削除。</li>
+                      </ul>
+                    </li>
+                  </ul>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <!-- Right Gap -->
+      <div class="column is-narrow w-24"></div>
+    </div>
   </div>
 </template>
+
+<style lang="scss" scoped>
+.article-list ul {
+  list-style: outside;
+  list-style-type: disc;
+  padding-left: 24px;
+}
+
+.article-list > ul {
+  list-style: none;
+  padding: 0;
+}
+.article-list > ul > li {
+  @extend .t-h6;
+  @extend .c-text-black-disabled;
+}
+.article-list > ul > li:not(:first-child) {
+  padding-top: 24px;
+}
+
+.article-list > ul > li ul li {
+  @extend .t-body1;
+  @extend .c-text-black-high;
+  margin-top: 16px;
+}
+</style>

--- a/src/app/admin/News/List.vue
+++ b/src/app/admin/News/List.vue
@@ -1,5 +1,59 @@
 <template>
   <div>
-    hello
+    <!-- List Header Area -->
+    <div class="columns is-gapless">
+      <!-- Left Gap -->
+      <div class="column is-narrow w-24"></div>
+      <!-- Center Column -->
+      <div class="column">
+        <div class="m-l-24 m-r-24 m-t-24">
+          <!-- Link Button -->
+          <nuxt-link :to="'/admin/restaurants'">
+            <div class="op-button-pill bg-form">
+              <i class="material-icons c-primary s-18">home</i>
+              <span class="c-primary t-button">{{$t("admin.news.adminTop")}}</span>
+            </div>
+          </nuxt-link>
+
+          <!-- Title -->
+          <div class="t-h6 c-text-black-disabled m-t-24">{{$t("admin.news.title")}}</div>
+        </div>
+      </div>
+      <!-- Right Gap -->
+      <div class="column is-narrow w-24"></div>
+    </div>
+
+    <!-- List Body Area -->
+    <div class="columns is-gapless">
+      <!-- Left Gap -->
+      <div class="column is-narrow w-24"></div>
+      <!-- Center Column -->
+      <div class="column">
+        <div class="m-l-24 m-r-16 m-t-16">
+          <!-- Articles -->
+          <div class="columns is-gapless is-multiline">
+            <!-- v-for="article in articles" -->
+
+            <list-item :date="'2020.06.04'" :title="'v0.5.1をリリースしました。'" :id="'undefined'" />
+            <list-item :date="'2020.05.28'" :title="'v0.4.2をリリースしました。'" :id="'20200528'" />
+            <list-item :date="'2020.05.23'" :title="'v0.4.0をリリースしました。'" :id="'20200523'" />
+            <list-item :date="'2020.05.14'" :title="'v0.3.5をリリースしました。'" :id="'20200514'" />
+            <list-item :date="'2020.05.11'" :title="'v0.3.4をリリースしました。'" :id="'20200511'" />
+          </div>
+        </div>
+      </div>
+      <!-- Right Gap -->
+      <div class="column is-narrow w-24"></div>
+    </div>
   </div>
 </template>
+
+<script>
+import ListItem from "~/app/admin/News/ListItem";
+
+export default {
+  components: {
+    ListItem
+  }
+};
+</script>

--- a/src/app/admin/News/ListItem.vue
+++ b/src/app/admin/News/ListItem.vue
@@ -1,0 +1,26 @@
+<template>
+  <!-- Item Card -->
+  <div class="column is-one-third">
+    <div class="h-full p-b-8 p-r-8">
+      <nuxt-link :to="'/admin/news/' + id">
+        <div class="touchable bg-surface r-8 d-low p-l-16 p-r-16 p-t-8 p-b-8 h-full">
+          <!-- Date -->
+          <div class="t-subtitle2 c-text-black-disabled">{{date}}</div>
+
+          <!-- Title -->
+          <div class="t-body1 c-text-black-high">{{title}}</div>
+        </div>
+      </nuxt-link>
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  props: {
+    date: String,
+    title: String,
+    id: String
+  }
+};
+</script>

--- a/src/assets/scss/ownplate.scss
+++ b/src/assets/scss/ownplate.scss
@@ -300,6 +300,9 @@ body,
 .w-full {
   width: 100%;
 }
+.h-full {
+  height: 100%;
+}
 
 // Cover Photo
 .cover {


### PR DESCRIPTION
お知らせ一覧と記事ページのデザインテンプレートを作成しましたので実装お願いします。
リリースノートを出したいときはGitHub上のRELEASES.mdのHTMLから`<ul><li>`部分をコピーして`<div class="article-list m-t-24">`配下にペーストすればCSSが適用されるようにしています。