### PR TITLE
use firebase's displayName to store user's name

### DIFF
--- a/src/app/auth/PhoneLogin.vue
+++ b/src/app/auth/PhoneLogin.vue
@@ -211,19 +211,11 @@ export default {
         );
         console.log("success!", result);
         if (this.name) {
-          await db.doc(`users/${result.user.uid}`).set(
-            {
-              name: this.name
-            },
-            { merge: true }
-          );
-          // Paranoia: To avoid race condition
-          const user = this.$store.state.user;
-          console.log("user", user);
+          const user = auth.currentUser; // paranoia: instead of this.$store.state.user;
           if (user) {
-            console.log("name", user.name, this.name);
-            user.name = this.name;
-            this.$store.commit("setUser", user);
+            await user.updateProfile({
+              displayName: this.name
+            });
           }
         }
 

--- a/src/app/user/RestaurantPage.vue
+++ b/src/app/user/RestaurantPage.vue
@@ -18,14 +18,8 @@
               <div class="column">
                 <div class="is-hidden-mobile h-24"></div>
                 <div class="bg-form h-192">
-                  <img
-                    :src="coverImage"
-                    class="h-192 w-full cover is-hidden-tablet"
-                  />
-                  <img
-                    :src="coverImage"
-                    class="h-192 w-full cover r-8 is-hidden-mobile"
-                  />
+                  <img :src="coverImage" class="h-192 w-full cover is-hidden-tablet" />
+                  <img :src="coverImage" class="h-192 w-full cover r-8 is-hidden-mobile" />
                 </div>
               </div>
               <div class="column is-narrow w-24"></div>
@@ -37,9 +31,9 @@
               <shop-header :shopInfo="shopInfo"></shop-header>
 
               <!-- Restaurant Descriptions -->
-              <div class="t-body1 c-text-black-medium align-center m-t-8">
-                {{ this.shopInfo.introduction }}
-              </div>
+              <div
+                class="t-body1 c-text-black-medium align-center m-t-8"
+              >{{ this.shopInfo.introduction }}</div>
 
               <!-- Share Popup -->
               <share-popup :shopInfo="shopInfo"></share-popup>
@@ -59,9 +53,7 @@
                     <div
                       class="t-h6 c-text-black-disabled m-t-24"
                       v-if="itemsObj[itemId]._dataType === 'title'"
-                    >
-                      {{ itemsObj[itemId].name }}
-                    </div>
+                    >{{ itemsObj[itemId].name }}</div>
                     <item-card
                       v-if="itemsObj[itemId]._dataType === 'menu'"
                       :item="itemsObj[itemId]"
@@ -105,7 +97,7 @@
         <div class="level is-mobile w-full p-l-32 p-r-32">
           <div class="level-left">
             {{
-              $tc("sitemenu.orderCounter", totalCount, { count: totalCount })
+            $tc("sitemenu.orderCounter", totalCount, { count: totalCount })
             }}
           </div>
           <div class="level-right">
@@ -293,7 +285,7 @@ export default {
         status: order_status.new_order,
         uid: this.user.uid,
         phoneNumber: this.user.phoneNumber,
-        name: this.$store.getters.name,
+        name: this.user.displayName,
         updatedAt: firestore.FieldValue.serverTimestamp(),
         timeCreated: firestore.FieldValue.serverTimestamp()
         // price never set here.

--- a/src/layouts/default.vue
+++ b/src/layouts/default.vue
@@ -280,16 +280,9 @@ export default {
         console.log(
           "authStateChanged:",
           user.email || user.phoneNumber,
-          user.uid
+          user.uid,
+          user.displayName
         );
-        if (this.isUser) {
-          const snapshot = await db.doc(`users/${user.uid}`).get();
-          const doc = snapshot.data();
-          if (doc && doc.name) {
-            user.name = doc.name;
-            console.log("user.name", doc.name);
-          }
-        }
         user.getIdTokenResult(true).then(result => {
           this.$store.commit("setUser", user);
           this.$store.commit("setCustomClaims", result.claims);

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -34,9 +34,6 @@ export const getters = {
     // Check if state.user has been initialized (as the result of notication from Firebase)
     return state.user !== undefined;
   },
-  name: (state) => {
-    return state.user && state.user.name || "";
-  },
   stripeRegion: (state) => {
     return stripe_regions[state.server.region || "US"];
   },


### PR DESCRIPTION
これまで、ユーザーがログイン時に入力した名前は db にしまっていましたが（そのためにオーダーに名前がちゃんと表示されないというバグが出ていました）、firebase の user.displayName を使うことにしました。それにより、user object と db の同期をする必要がなくなりました。