### PR TITLE
pass timezone to orderUpdate

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9063,6 +9063,14 @@
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
       "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg=="
     },
+    "moment-timezone": {
+      "version": "0.5.31",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.31.tgz",
+      "integrity": "sha512-+GgHNg8xRhMXfEbv81iDtrVeTcWt0kWmTEY1XQK14dICTXnWJnT0dxdlPspwqF3keKMVPXwayEsk1DI0AA/jdA==",
+      "requires": {
+        "moment": ">= 2.9.0"
+      }
+    },
     "move-concurrently": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "google-libphonenumber": "^3.2.8",
     "markdown-it": "^11.0.0",
     "moment": "^2.24.0",
+    "moment-timezone": "^0.5.31",
     "nuxt": "^2.0.0",
     "nuxt-buefy": "^0.3.2",
     "nuxt-gmaps": "^1.1.9",

--- a/src/app/admin/OrderInfoPage.vue
+++ b/src/app/admin/OrderInfoPage.vue
@@ -185,7 +185,7 @@ import {
   formatURL
 } from "~/plugins/phoneutil.js";
 import { stripeConfirmIntent, stripeCancelIntent } from "~/plugins/stripe.js";
-import moment from "moment";
+import moment from "moment-timezone";
 import NotFound from "~/components/NotFound";
 
 export default {
@@ -369,6 +369,7 @@ export default {
       }
     },
     async handleChangeStatus(statusKey) {
+      const timezone = moment.tz.guess();
       const newStatus = order_status[statusKey];
       if (newStatus === this.orderInfo.status) {
         return;
@@ -379,7 +380,8 @@ export default {
         const { data } = await orderUpdate({
           restaurantId: this.restaurantId() + this.forcedError("update"),
           orderId: this.orderId,
-          status: newStatus
+          status: newStatus,
+          timezone
         });
         console.log("update", data);
         this.$router.push(this.parentUrl);


### PR DESCRIPTION
受け渡し希望時刻→受け渡し予定時刻を実装するための、一連のPRの最初のものです。
orderUpdate に timezone を渡しています。
timezone をサーバー側で required にしたいので、まずはクライアントのみ変更します。