### PR TITLE
Stripe "no save" option

### DIFF
--- a/functions/src/stripe/customer.ts
+++ b/functions/src/stripe/customer.ts
@@ -69,6 +69,13 @@ export const update = async (db: FirebaseFirestore.Firestore, data: any, context
         tr.set(refStripeReadOnly, {
           card
         }, { merge: true })
+      } else {
+        // We need to delete the old card info (if exists). Otherwise, the new one will become the default and
+        // will be reused (even though the end-user unchecks the "re-user" checkbox).
+        // This is a little bit incombinient (the user can not reuse the first one any more,
+        // after using the second one even though she/he uncheks the 'reuse' button), but this is better
+        // than introducing the complexity of managing multiple cards.
+        tr.delete(refStripeReadOnly)
       }
 
       await stripe.customers.update(stripeInfo.customerId, {

--- a/lang/en.json
+++ b/lang/en.json
@@ -225,6 +225,7 @@
     "salesTax": "Sales Tax",
     "total": "Total",
     "yourPayment": "Your Payment",
+    "reuseCard": "Save it for future use",
     "whatsCVC": "What’s CVC?",
     "3digitsCVC": "The final three digits on the back",
     "4digitsCVC": "The four digits on the front",

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -225,6 +225,7 @@
     "salesTax": "消費税",
     "total": "合計",
     "yourPayment": "お支払い",
+    "reuseCard": "今後の支払いのために保存する",
     "whatsCVC": "CVCとは？",
     "3digitsCVC": "カードのうら面の右端3ケタ",
     "4digitsCVC": "カードのおもて面の4ケタ",

--- a/src/app/user/Order/StripeCard.vue
+++ b/src/app/user/Order/StripeCard.vue
@@ -54,6 +54,10 @@
           </div>
         </b-modal>
       </div>
+      <!-- Save Card Info for Reuse -->
+      <div class="m-l-16 m-t-8">
+        <b-checkbox v-model="reuse">{{ $t('order.reuseCard') }}</b-checkbox>
+      </div>
     </div>
   </div>
 </template>
@@ -70,7 +74,8 @@ export default {
       useStoredCard: false,
       elementStatus: { complete: false },
       cardElement: {},
-      CVCPopup: false
+      CVCPopup: false,
+      reuse: true
     };
   },
   async mounted() {
@@ -95,7 +100,10 @@ export default {
         const { token } = await this.stripe.createToken(this.cardElement);
         const tokenId = token.id + this.forcedError("token");
         //console.log("***toke", token, token.card.last4);
-        const { data } = await stripeUpdateCustomer({ tokenId });
+        const { data } = await stripeUpdateCustomer({
+          tokenId,
+          reuse: this.reuse
+        });
         console.log("stripeUpdateCustomer", data, tokenId);
       }
     },


### PR DESCRIPTION
このPRで、ユーザーがカード情報を「今後の支払いのために保存する」かどうかを選べるようにしました。
この部分の実装は、connected account と customer が関わっているため少し厄介です。

本気で全てのシナリオを完璧にこなすためには、複数のカード情報をcustomerと関連付け、どれを使うか、どれを再利用するか、などの管理が必要になりますが、それをすると、コードもUIも複雑になります。

そこで、２つ目のカードが使われた時には、１つ目のカードの情報は上書きするように（二つ同時に覚えない）ように実装してあります。

今回の変更により、「今後の支払いのために保存しない」ことが可能になりましたが、そのサイドエフェクトとして、１つのカードを保存して使っていたユーザーが、二つ目のカードをたまたま使う必要があり、その時に「今後の支払いのために保存しない」ことを選択した場合でも、１つ目のカードの再利用が出来なくなってしまいます（もう一度カード情報を入れてもらう必要があります）。とても稀なケースなので、これでも十分だと思いますが、念のために書いておきます。