### PR TITLE
Global loading animation

### DIFF
--- a/src/app/user/OrderPage.vue
+++ b/src/app/user/OrderPage.vue
@@ -80,12 +80,10 @@
                 <b-button
                   v-if="just_paid"
                   class="b-reset op-button-text bg-transparent"
-                  :loading="isCanceling"
                   @click="handleCancelPayment"
                 >
                   <i class="material-icons c-status-red s-18">highlight_off</i>
                   <span class="c-status-red">{{ $t("order.cancelOrder") }}</span>
-
                 </b-button>
               </div>
 
@@ -329,7 +327,6 @@ export default {
       isDeleting: false,
       isPlacing: false,
       tip: 0,
-      isCanceling: false,
       sendSMS: true,
       paymentInfo: {},
       notFound: false
@@ -579,6 +576,7 @@ export default {
         code: "order.cancelOrderConfirm",
         callback: async () => {
           try {
+            this.$store.commit("setLoading", true);
             this.isCanceling = true;
             const { data } = await stripeCancelIntent({
               restaurantId: this.restaurantId() + this.forcedError("cancel"),
@@ -593,7 +591,7 @@ export default {
               error
             });
           } finally {
-            this.isCanceling = false;
+            this.$store.commit("setLoading", false);
           }
         }
       });

--- a/src/app/user/OrderPage.vue
+++ b/src/app/user/OrderPage.vue
@@ -577,7 +577,6 @@ export default {
         callback: async () => {
           try {
             this.$store.commit("setLoading", true);
-            this.isCanceling = true;
             const { data } = await stripeCancelIntent({
               restaurantId: this.restaurantId() + this.forcedError("cancel"),
               orderId: this.orderId

--- a/src/layouts/default.vue
+++ b/src/layouts/default.vue
@@ -53,6 +53,9 @@
       </div>
     </div>
 
+    <!-- Loading -->
+    <b-loading v-if="isLoading" :is-full-page="true" :active="true" :can-cancel="false"></b-loading>
+
     <!-- Footer -->
     <div class="m-t-48">
       <div class="bg-ownplate-gray cols h-128">
@@ -130,8 +133,7 @@ export default {
       fullwidth: false,
       right: false,
 
-      langPopup: false,
-
+      langPopup: false
     };
   },
   mounted() {
@@ -143,6 +145,9 @@ export default {
     });
   },
   computed: {
+    isLoading() {
+      return this.$store.state.isLoading;
+    },
     dialog() {
       return this.$store.state.dialog;
     },
@@ -226,7 +231,7 @@ export default {
         // save into store
         this.$store.commit("setLang", lang);
       }
-    },
+    }
   },
   beforeCreate() {
     const systemGetConfig = functions.httpsCallable("systemGetConfig");

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -18,7 +18,8 @@ export const state = () => ({
   soundOn: false, // for restaurant admin config
   soundFile: "",
   isWindowActive: false, // active status of browser window
-  dialog: null // for DialogBox
+  dialog: null, // for DialogBox
+  isLoading: false // for full-page loading animation
 });
 
 export const getters = {
@@ -49,6 +50,9 @@ export const getters = {
 export const mutations = {
   setActive(state, flag) {
     state.isWindowActive = flag;
+  },
+  setLoading(state, flag) {
+    state.isLoading = flag;
   },
   setUser(state, user) {
     state.user = user;


### PR DESCRIPTION
ページ全体にローディング・アニメーションを表示する仕組みを作りました。
this.$store.commit("setLoading", true or false);
でオン・オフします。まずは、オーダーのキャンセルで使っています。