### PR TITLE
Stripe link

### DIFF
--- a/src/app/admin/OrderInfoPage.vue
+++ b/src/app/admin/OrderInfoPage.vue
@@ -53,7 +53,7 @@
                         v-if="hasStripe"
                         class="t-body1 c-textl-black-high is-inline-flex flex-center"
                       >
-                        <a :href="search" target="_blank">
+                        <a :href="search" target="stripe">
                           <span>{{$n(orderInfo.totalCharge, 'currency')}}</span>
                           <i :class="'fab fa-cc-stripe stripe_'+orderInfo.payment.stripe"></i>
                         </a>
@@ -273,7 +273,9 @@ export default {
   },
   computed: {
     search() {
-      const value = encodeURIComponent(this.orderName);
+      const value = encodeURIComponent(
+        this.orderInfo.description || this.orderName
+      );
       return `${ownPlateConfig.stripe.search}?query=${value}`;
     },
     showTimePicker() {

--- a/src/app/admin/OrderInfoPage.vue
+++ b/src/app/admin/OrderInfoPage.vue
@@ -49,11 +49,17 @@
                     <!-- Total Charge -->
                     <div class="m-l-16">
                       <div class="t-caption c-text-black-medium">{{$t('order.totalCharge')}}</div>
-                      <div class="t-body1 c-textl-black-high is-inline-flex flex-center">
-                        <div>{{$n(orderInfo.totalCharge, 'currency')}}</div>
-                        <div v-if="hasStripe" class="m-l-4">
+                      <div
+                        v-if="hasStripe"
+                        class="t-body1 c-textl-black-high is-inline-flex flex-center"
+                      >
+                        <a :href="search" target="_blank">
+                          <span>{{$n(orderInfo.totalCharge, 'currency')}}</span>
                           <i :class="'fab fa-cc-stripe stripe_'+orderInfo.payment.stripe"></i>
-                        </div>
+                        </a>
+                      </div>
+                      <div v-else class="t-body1 c-textl-black-high is-inline-flex flex-center">
+                        <div>{{$n(orderInfo.totalCharge, 'currency')}}</div>
                       </div>
                     </div>
                   </div>
@@ -203,6 +209,7 @@ import {
 import { stripeConfirmIntent, stripeCancelIntent } from "~/plugins/stripe.js";
 import moment from "moment-timezone";
 import NotFound from "~/components/NotFound";
+import { ownPlateConfig } from "~/config/project";
 
 export default {
   components: {
@@ -265,6 +272,10 @@ export default {
     });
   },
   computed: {
+    search() {
+      const value = encodeURIComponent(this.orderName);
+      return `${ownPlateConfig.stripe.search}?query=${value}`;
+    },
     showTimePicker() {
       return this.orderInfo.status === order_status.order_placed;
     },

--- a/src/app/admin/Payment/PaymentSection.vue
+++ b/src/app/admin/Payment/PaymentSection.vue
@@ -33,7 +33,7 @@
           >{{ $t("admin.payments.statusConnected") }}</div>
         </div>
         <div class="align-center m-t-24">
-          <a :href="dashboard" target="_blank">
+          <a :href="dashboard" target="stripe">
             <div class="op-button-small secondary">
               <span class="c-primary">
                 {{

--- a/src/app/admin/Payment/PaymentSection.vue
+++ b/src/app/admin/Payment/PaymentSection.vue
@@ -33,7 +33,7 @@
           >{{ $t("admin.payments.statusConnected") }}</div>
         </div>
         <div class="align-center m-t-24">
-          <a href="https://dashboard.stripe.com/dashboard" target="_blank">
+          <a :href="dashboard" target="_blank">
             <div class="op-button-small secondary">
               <span class="c-primary">
                 {{
@@ -75,6 +75,7 @@
 import { db, firestore, functions } from "~/plugins/firebase.js";
 import { releaseConfig } from "~/plugins/config.js";
 import { stripeConnect, stripeDisconnect } from "~/plugins/stripe.js";
+import { ownPlateConfig } from "~/config/project";
 export default {
   data() {
     return {
@@ -136,6 +137,9 @@ export default {
     }
   },
   computed: {
+    dashboard() {
+      return ownPlateConfig.stripe.dashboard;
+    },
     uid() {
       return this.$store.getters.uidAdmin;
     },

--- a/src/config/default/ownplate-dev.js
+++ b/src/config/default/ownplate-dev.js
@@ -15,6 +15,9 @@ export const ownPlateConfig = {
   releasName: "beta-dev",
   region: "JP",
   hostName: "staging.ownplate.today",
+  stripe: {
+    dashboard: "https://dashboard.stripe.com/test/dashboard",
+  },
   line: {
     LOGIN_CHANNEL_ID: "1654216149",
     TRACK_CHANNEL_ID: "1654259709",

--- a/src/config/default/ownplate-dev.js
+++ b/src/config/default/ownplate-dev.js
@@ -17,6 +17,7 @@ export const ownPlateConfig = {
   hostName: "staging.ownplate.today",
   stripe: {
     dashboard: "https://dashboard.stripe.com/test/dashboard",
+    search: "https://dashboard.stripe.com/test/search",
   },
   line: {
     LOGIN_CHANNEL_ID: "1654216149",

--- a/src/config/default/ownplate-eu.js
+++ b/src/config/default/ownplate-eu.js
@@ -17,5 +17,6 @@ export const ownPlateConfig = {
   hostName: "eu.ownplate.today",
   stripe: {
     dashboard: "https://dashboard.stripe.com/dashboard",
+    search: "https://dashboard.stripe.com/search",
   },
 };

--- a/src/config/default/ownplate-eu.js
+++ b/src/config/default/ownplate-eu.js
@@ -14,5 +14,8 @@ export const ownPlateConfig = {
   siteDescription: "Zero Comission Take-out Service",
   releasName: "alpha",
   region: "EU",
-  hostName: "eu.ownplate.today"
+  hostName: "eu.ownplate.today",
+  stripe: {
+    dashboard: "https://dashboard.stripe.com/dashboard",
+  },
 };

--- a/src/config/default/ownplate-jp.js
+++ b/src/config/default/ownplate-jp.js
@@ -15,6 +15,9 @@ export const ownPlateConfig = {
   releasName: "beta",
   region: "JP",
   hostName: "omochikaeri.com",
+  stripe: {
+    dashboard: "https://dashboard.stripe.com/dashboard",
+  },
   line: {
     LOGIN_CHANNEL_ID: "1654216149",
     TRACK_CHANNEL_ID: "1654259709",

--- a/src/config/default/ownplate-jp.js
+++ b/src/config/default/ownplate-jp.js
@@ -17,6 +17,7 @@ export const ownPlateConfig = {
   hostName: "omochikaeri.com",
   stripe: {
     dashboard: "https://dashboard.stripe.com/dashboard",
+    search: "https://dashboard.stripe.com/search",
   },
   line: {
     LOGIN_CHANNEL_ID: "1654216149",

--- a/src/config/default/ownplate.js
+++ b/src/config/default/ownplate.js
@@ -17,6 +17,7 @@ export const ownPlateConfig = {
   hostName: "ownplate.today",
   stripe: {
     dashboard: "https://dashboard.stripe.com/dashboard",
+    search: "https://dashboard.stripe.com/search",
   },
 };
 

--- a/src/config/default/ownplate.js
+++ b/src/config/default/ownplate.js
@@ -14,7 +14,10 @@ export const ownPlateConfig = {
   siteDescription: "Zero Comission Take-out Service",
   releasName: "beta",
   region: "US",
-  hostName: "ownplate.today"
+  hostName: "ownplate.today",
+  stripe: {
+    dashboard: "https://dashboard.stripe.com/dashboard",
+  },
 };
 
 export const sentryDsn = 'https://370e22db44d64d028df9d40829999274@o391740.ingest.sentry.io/5238405';


### PR DESCRIPTION
admin 向けのオーダー個別ページで、値段＋Stripeの部分をタップすると、description （新たに order document のプロパティとしてセーブすることにしたもの）で stripe にサーチをかけるようにしました。これにより、特定のオーダーに紐づく Stripe のトランザクションを見つけることが可能にになります。
description をユニークなものにするために、orderId を加えました。

既存のオーダーに関しては、オーダー名（#542 など）でサーチします。

同時に、stripe dashboard へのURLを project.js ファイルで指定するようにしました。これにより、staging の場合のみ test の dashboard を開くことが可能になります。

また、これまで dashboard は target=_blank で開いていましたが、それをするとタブが増えてしまうので、target=stripe で開くようにしました。