### PR TITLE
feat: add i18n ally vscode settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,7 +8,6 @@
   "editor.formatOnPaste": true,
   "editor.formatOnSave": true,
   "i18n-ally.localesPaths": [
-    "lang",
-    "functions/src/lang"
+    "lang"
   ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,9 +6,9 @@
   "editor.tabSize": 2,
   "editor.formatOnType": true,
   "editor.formatOnPaste": true,
-	"editor.formatOnSave": true,
-	"i18n-ally.localesPaths": [
-		"lang",
-		"functions/src/lang"
-	]
+  "editor.formatOnSave": true,
+  "i18n-ally.localesPaths": [
+    "lang",
+    "functions/src/lang"
+  ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,5 +6,9 @@
   "editor.tabSize": 2,
   "editor.formatOnType": true,
   "editor.formatOnPaste": true,
-  "editor.formatOnSave": true
+	"editor.formatOnSave": true,
+	"i18n-ally.localesPaths": [
+		"lang",
+		"functions/src/lang"
+	]
 }


### PR DESCRIPTION
Purpose: Add custom settings for the i18n-ally extension (https://github.com/antfu/i18n-ally)
 
I discovered this extension a couple of days ago, and it drastically improves the developer experience when having to deal with i18n and translations. It also features editing & commenting for i18n all managed with vscode and git! I really encourage you to try it out if you already haven't already

btw, 
sorry if it the extension and the settings are already utilized by the contributors, 
and I may need time to contribute to the source code itself since I haven't come across developing with vue before :)