### PR TITLE
Pass real error object to Sentry

### DIFF
--- a/src/app/auth/TrackCallback.vue
+++ b/src/app/auth/TrackCallback.vue
@@ -64,7 +64,7 @@ export default {
           throw new Error("something is wrong");
         }
       } catch (error) {
-        console.error(error.message, error.details);
+        console.error(error.message, error.details, error.details?.params);
         this.$store.commit("setErrorMessage", {
           code: "line.validation",
           message2: "errorPage.message.line",

--- a/src/components/DialogBox.vue
+++ b/src/components/DialogBox.vue
@@ -10,17 +10,13 @@
         <div v-if="error">
           <!-- Message -->
           <div class="align-center m-t-16">
-            <div class="t-h6 c-text-black-medium">
-              {{ $t("errorPage.popup.title") }}
-            </div>
+            <div class="t-h6 c-text-black-medium">{{ $t("errorPage.popup.title") }}</div>
             <div class="m-t-8">{{ errorMessage }}</div>
             <div class="m-t-8">{{ $t(errorMessage2) }}</div>
           </div>
           <!-- Buttons -->
           <div class="m-t-24 align-center">
-            <div class="op-button-small tertiary" @click="close">
-              {{ $t("menu.close") }}
-            </div>
+            <div class="op-button-small tertiary" @click="close">{{ $t("menu.close") }}</div>
           </div>
         </div>
 
@@ -28,21 +24,15 @@
         <div v-if="alert">
           <!-- Message -->
           <div class="align-center m-t-16">
-            <div class="t-h6 c-text-black-medium">
-              {{ $t(alert.code) }}
-            </div>
+            <div class="t-h6 c-text-black-medium">{{ $t(alert.code) }}</div>
           </div>
           <!-- Buttons -->
           <div class="m-t-24 align-center">
-            <div class="op-button-small tertiary m-r-16" @click="close">
-              {{ $t("menu.no") }}
-            </div>
+            <div class="op-button-small tertiary m-r-16" @click="close">{{ $t("menu.no") }}</div>
             <div
               class="op-button-small bg-status-red c-text-white-full"
               @click="handleYes"
-            >
-              {{ $t("menu.yes") }}
-            </div>
+            >{{ $t("menu.yes") }}</div>
           </div>
         </div>
       </div>
@@ -82,7 +72,7 @@ export default {
       return this.dialog?.error;
     },
     errorMessage() {
-      Sentry.captureException(this.error);
+      Sentry.captureException(this.error?.error);
       if (this.error.message) {
         return this.error.message;
       } else if (this.error.code) {


### PR DESCRIPTION
DialogBox.vue で Sentry.captureException に実際の（catch で捉えた）error object を渡すように変更しました。