### PR TITLE
Tweak copies for Payment Method info in User Restaurant page.

### DIFF
--- a/lang/ja.json
+++ b/lang/ja.json
@@ -195,8 +195,8 @@
     "closed": "定休日",
     "public": "公開",
     "paymentMethod": "支払い方法",
-    "onlinePayment": "オンライン決済あり",
-    "onsitePayment": "受け取り払いあり"
+    "onlinePayment": "オンライン決済",
+    "onsitePayment": "受け取り払い"
   },
   "transactionsAct": {
     "title": "特定商取引法に基づく表記",


### PR DESCRIPTION
https://app.asana.com/0/search/1181523962564153/1178846954750749
「〜あり」だと他のデフォルトオプションが存在する印象を受けるので（例：オンライン決済あり＝オフライン現金払いはデフォルト？）、あり/なしは取ってしまって単純に決済方法のみ記述する方が良い気がします。