### PR TITLE
removed warning

### DIFF
--- a/src/routes.js
+++ b/src/routes.js
@@ -60,7 +60,6 @@ export const customRoutes = [
     component: "admin/Index.vue"
   },
   {
-    name: "admin-router",
     path: "/admin/restaurants/:restaurantId",
     component: "admin/Layout.vue",
     children: [


### PR DESCRIPTION
routes.js で、children のあるノードに名前があるとワーニングが出るので外しました。