### PR TITLE
auth.signInWithEmailAndPassword bug work around

### DIFF
--- a/src/app/auth/SignInPage.vue
+++ b/src/app/auth/SignInPage.vue
@@ -116,23 +116,24 @@ export default {
       this.$router.push("/");
     },
     async onSignin() {
-      try {
-        this.isLoading = true;
-        this.errors = {};
-        await auth.signInWithEmailAndPassword(this.email, this.password);
-        console.log("onSignin success");
-        //this.$router.push("/admin/restaurants");
-      } catch (error) {
-        console.log("onSignin failed", error.code, error.message);
-        const errorCode = "admin.error.code." + error.code;
-        if (error.code === "auth/wrong-password") {
-          this.errors = { password: [errorCode] };
-        } else {
-          this.errors = { email: [errorCode] };
-        }
-      } finally {
-        this.isLoading = false;
-      }
+      this.isLoading = true;
+      this.errors = {};
+      auth
+        .signInWithEmailAndPassword(this.email, this.password)
+        .then(ret => {
+          console.log("onSignin success");
+          this.isLoading = false;
+        })
+        .catch(error => {
+          console.log("onSignin failed", error.code, error.message);
+          const errorCode = "admin.error.code." + error.code;
+          if (error.code === "auth/wrong-password") {
+            this.errors = { password: [errorCode] };
+          } else {
+            this.errors = { email: [errorCode] };
+          }
+          this.isLoading = false;
+        });
     }
   }
 };

--- a/src/app/auth/SignInPage.vue
+++ b/src/app/auth/SignInPage.vue
@@ -50,11 +50,7 @@
                     <b-button class="b-reset op-button-small tertiary m-r-16" @click="handleCancel">
                       <span class="c-text-black-medium">{{ $t('button.cancel') }}</span>
                     </b-button>
-                    <b-button
-                      class="b-reset op-button-small primary"
-                      :loading="isLoading"
-                      @click="onSignin"
-                    >
+                    <b-button class="b-reset op-button-small primary" @click="onSignin">
                       <span class="c-onprimary">{{ $t('button.next') }}</span>
                     </b-button>
                   </div>
@@ -99,7 +95,6 @@ export default {
     return {
       email: "",
       password: "",
-      isLoading: false,
       errors: {}
     };
   },
@@ -116,13 +111,13 @@ export default {
       this.$router.push("/");
     },
     async onSignin() {
-      this.isLoading = true;
+      this.$store.commit("setLoading", true);
       this.errors = {};
       auth
         .signInWithEmailAndPassword(this.email, this.password)
         .then(ret => {
           console.log("onSignin success");
-          this.isLoading = false;
+          this.$store.commit("setLoading", false);
         })
         .catch(error => {
           console.log("onSignin failed", error.code, error.message);
@@ -132,7 +127,7 @@ export default {
           } else {
             this.errors = { email: [errorCode] };
           }
-          this.isLoading = false;
+          this.$store.commit("setLoading", false);
         });
     }
   }


### PR DESCRIPTION
Sentry に送られてくる"The email address is badly formatted"ですが、これは auth.signInWithEmailAndPasswor の exception が try-await-catch だけでは全部補足出来ないためです（Firebase のバグです）。この PR は、この問題を、then/catch を使って回避するものです。
ついでに、個別の this.isLoading=true/false を this.$store.commit("setLoading", true/false) を置き換えました。