### PR TITLE
Avoid uid of undefined

### DIFF
--- a/src/app/user/RestaurantPage.vue
+++ b/src/app/user/RestaurantPage.vue
@@ -248,7 +248,7 @@ export default {
       return this.notFound && this.isOwner;
     },
     isOwner() {
-      return this.isAdmin && this.uid === this.shopInfo.uid;
+      return this.isAdmin && this.uid === this.shopInfo?.uid;
     },
     isUser() {
       return !!this.$store.getters.uidUser;

--- a/src/app/user/RestaurantPage.vue
+++ b/src/app/user/RestaurantPage.vue
@@ -190,7 +190,7 @@ export default {
       .doc(`restaurants/${this.restaurantId()}`)
       .onSnapshot(restaurant => {
         const restaurant_data = restaurant.data();
-        this.shopInfo = restaurant_data;
+        this.shopInfo = restaurant_data || {};
         if (
           restaurant.exists &&
           !restaurant.data().deletedFlag &&
@@ -248,7 +248,7 @@ export default {
       return this.notFound && this.isOwner;
     },
     isOwner() {
-      return this.isAdmin && this.uid === this.shopInfo?.uid;
+      return this.isAdmin && this.uid === this.shopInfo.uid;
     },
     isUser() {
       return !!this.$store.getters.uidUser;


### PR DESCRIPTION
Sentry でレポートされた Cannot read property 'uid' of undefined を解析した結果、別のバグかもしれませんが、存在しない restaurantId を指定した場合にこのエラーがでてしまうことが分かったので修正します。

https://sentry.io/organizations/ownplate/issues/1747142737/?project=5238403&referrer=slack