### PR TITLE
Inclusive tax

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -240,6 +240,7 @@
     "editItems": "Edit Items",
     "subtotal": "Subtotal",
     "salesTax": "Sales Tax",
+    "inclusiveTax": "Sales Tax (inclusive)",
     "total": "Total",
     "yourPayment": "Your Payment",
     "reuseCard": "Save it for future use",

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -240,6 +240,7 @@
     "editItems": "注文を変更する",
     "subtotal": "小計",
     "salesTax": "消費税",
+    "inclusiveTax": "消費税（内税）",
     "total": "合計",
     "yourPayment": "お支払い",
     "reuseCard": "今後の支払いのために保存する",

--- a/src/app/admin/RestaurantPage.vue
+++ b/src/app/admin/RestaurantPage.vue
@@ -16,7 +16,7 @@
               <div class="level-left flex-1"></div>
               <!-- Notification Settings -->
               <div class="level-right">
-                <notification-index :shopInfo="shopInfo"/>
+                <notification-index :shopInfo="shopInfo" />
               </div>
             </div>
 
@@ -473,7 +473,7 @@
                 >{{ $t("editRestaurant.taxPriceDisplay") }}</div>
                 <div class="bg-form r-8 p-l-16 p-r-16 p-t-16 p-b-16 t-body1 c-text-black-high">
                   <div>
-                    <b-checkbox v-model="shopInfo.taxInclude">
+                    <b-checkbox v-model="shopInfo.inclusiveTax">
                       {{
                       $t("editRestaurant.taxIncluded")
                       }}
@@ -746,7 +746,7 @@ export default {
         orderThanks: "",
         foodTax: 0,
         alcoholTax: 0,
-        taxInclude: 0,
+        inclusiveTax: false,
         openTimes: {
           1: [], // mon
           2: [],
@@ -815,13 +815,13 @@ export default {
     restProfilePhoto() {
       return (
         (this.shopInfo?.images?.profile?.resizedImages || {})["600"] ||
-          this.shopInfo.restProfilePhoto
+        this.shopInfo.restProfilePhoto
       );
     },
     restCoverPhoto() {
       return (
         (this.shopInfo?.images?.cover?.resizedImages || {})["600"] ||
-          this.shopInfo.restCoverPhoto
+        this.shopInfo.restCoverPhoto
       );
     },
     uid() {
@@ -891,8 +891,8 @@ export default {
       const ex = new RegExp("^(https?)://[^\\s]+$");
       err["url"] =
         this.shopInfo.url && !ex.test(this.shopInfo.url)
-        ? ["validationError.url.invalidUrl"]
-        : [];
+          ? ["validationError.url.invalidUrl"]
+          : [];
 
       err["time"] = {};
       Object.keys(daysOfWeek).forEach(key => {
@@ -902,7 +902,7 @@ export default {
           if (this.shopInfo.businessDay[key]) {
             if (
               this.shopInfo.openTimes[key] &&
-                this.shopInfo.openTimes[key][key2]
+              this.shopInfo.openTimes[key][key2]
             ) {
               const data = this.shopInfo.openTimes[key][key2];
               if (this.isNull(data.start) ^ this.isNull(data.end)) {
@@ -947,9 +947,13 @@ export default {
   },
   methods: {
     copyPreviousDay(index) {
-      const prevIndex = (index === "1") ? 7 : index - 1;
+      const prevIndex = index === "1" ? 7 : index - 1;
       this.shopInfo.businessDay[index] = this.shopInfo.businessDay[prevIndex];
-      this.shopInfo.openTimes[index] = this.shopInfo.openTimes[prevIndex].map((a) => {return {...a};});
+      this.shopInfo.openTimes[index] = this.shopInfo.openTimes[prevIndex].map(
+        a => {
+          return { ...a };
+        }
+      );
     },
     handleProfileImage(e) {
       this.files["profile"] = e;
@@ -1033,7 +1037,7 @@ export default {
           businessDay: this.shopInfo.businessDay,
           uid: this.shopInfo.uid,
           publicFlag: this.shopInfo.publicFlag,
-          taxInclude: this.shopInfo.taxInclude,
+          inclusiveTax: this.shopInfo.inclusiveTax,
           updatedAt: firestore.FieldValue.serverTimestamp(),
           createdAt:
             this.shopInfo.createdAt || firestore.FieldValue.serverTimestamp()

--- a/src/app/user/Order/OrderInfo.vue
+++ b/src/app/user/Order/OrderInfo.vue
@@ -30,7 +30,9 @@
       <div class="p-t-8 p-l-16 p-r-16">
         <div class="cols">
           <div class="flex-1">
-            <div class="t-body1 c-text-black-high">{{$t('order.salesTax')}}</div>
+            <div
+              class="t-body1 c-text-black-high"
+            >{{$t(orderInfo.inclusiveTax ? 'order.inclusiveTax':'order.salesTax')}}</div>
           </div>
           <div class="align-righ">
             <span class="t-body1 c-text-black-high">{{$n(orderInfo.tax, 'currency')}}</span>

--- a/src/app/user/OrderPage.vue
+++ b/src/app/user/OrderPage.vue
@@ -443,6 +443,7 @@ export default {
           if (restaurant.exists) {
             const restaurant_data = restaurant.data();
             this.shopInfo = restaurant_data;
+            console.log("*** R", this.shopInfo);
             const uid = restaurant_data.uid;
             const snapshot = await db
               .doc(`/admins/${uid}/public/payment`)
@@ -459,6 +460,7 @@ export default {
           async order => {
             const order_data = order.exists ? order.data() : {};
             this.orderInfo = order_data;
+            console.log("*** O", this.orderInfo);
             if (this.orderInfo.menuItems) {
               this.menuObj = this.orderInfo.menuItems;
             } else {

--- a/src/components/Price.vue
+++ b/src/components/Price.vue
@@ -1,13 +1,13 @@
 <template>
   <span>
-    <span v-if="shopInfo.taxInclude">
-      {{$tc('tax.price', taxObj.total_price_i18n) }}
+    <span v-if="shopInfo.inclusiveTax">
+      {{$tc('tax.price', taxObj.price_i18n) }}
       <span
         class="t-caption c-text-black-medium"
       >{{$tc('tax.include')}}</span>
       <br />
     </span>
-    <span v-if="!shopInfo.taxInclude">
+    <span v-if="!shopInfo.inclusiveTax">
       {{$tc('tax.price', taxObj.price_i18n)}}
       <span
         class="t-caption c-text-black-medium"
@@ -33,18 +33,9 @@ export default {
   computed: {
     taxObj() {
       const price = Number(this.menu.price);
-      const multiple = this.$store.getters.stripeRegion.multiple;
-      const taxRate =
-        this.menu.tax === "alcohol"
-          ? this.shopInfo.alcoholTax
-          : this.shopInfo.foodTax;
-      const tax = Math.round(((price * taxRate) / 100) * multiple) / multiple;
-      const total = price + tax;
 
       return {
-        price_i18n: this.$n(price, "currency"),
-        tax_i18n: this.$n(tax, "currency"),
-        total_price_i18n: this.$n(total, "currency")
+        price_i18n: this.$n(price, "currency")
       };
     }
   }


### PR DESCRIPTION
内税をちゃんとサポートするように変更しました。
1. 店が指定する値段は税込みの値段です
2. 客には、その値段を税込みの値段として表示します
3. サーバー側では、内税の場合、税金は逆算して求めますが、合計はしません。
4. 客向けのオーダーページには、内税の場合には内税と明記します。

ちなみに、意味合いがこれまでの taxInclude フラグとは違うので、新たなフラグ inclusiveTax を導入しました。