### PR TITLE
Ignore DB errors in various notification UI

### DIFF
--- a/src/app/admin/Layout.vue
+++ b/src/app/admin/Layout.vue
@@ -72,8 +72,12 @@ export default {
           this.justCreated = false;
         },
         error => {
-          // We can ignore this error here
-          console.error(error.message);
+          if (error.code === "permission-denied") {
+            // We can ignore this type of error here
+            console.warn("Ignoring", error.code);
+          } else {
+            throw error;
+          }
         }
       );
   },

--- a/src/app/admin/Layout.vue
+++ b/src/app/admin/Layout.vue
@@ -7,7 +7,6 @@
       @close="closeNotificationSettings"
       v-if="NotificationSettingsPopup"
     />
-
     <router-view></router-view>
     <notification-watcher />
     <sound-config-watcher :notificationConfig="notificationConfig" />
@@ -57,23 +56,29 @@ export default {
   async created() {
     this.notification_detacher = db
       .doc(`restaurants/${this.restaurantId()}/private/notifications`)
-      .onSnapshot(notification => {
-        console.log("onSnapshot");
-        if (notification.exists) {
-          this.notificationConfig = Object.assign(
-            this.notificationConfig,
-            notification.data()
-          );
+      .onSnapshot(
+        notification => {
+          console.log("onSnapshot");
+          if (notification.exists) {
+            this.notificationConfig = Object.assign(
+              this.notificationConfig,
+              notification.data()
+            );
+          }
+          if (this.justCreated && this.requestTouch) {
+            console.log("*** show Sound Test");
+            this.NotificationSettingsPopup = true;
+          }
+          this.justCreated = false;
+        },
+        error => {
+          // We can ignore this error here
+          console.error(error.message);
         }
-        if (this.justCreated && this.requestTouch) {
-          console.log("*** show Sound Test");
-          this.NotificationSettingsPopup = true;
-        }
-        this.justCreated = false;
-      });
+      );
   },
   destroyed() {
-    this.notification_detacher();
+    this.notification_detacher && this.notification_detacher();
   },
   methods: {
     closeNotificationSettings() {

--- a/src/app/admin/Notifications/Index.vue
+++ b/src/app/admin/Notifications/Index.vue
@@ -1,20 +1,20 @@
 <template>
-<div>
-  <!-- Notification Settings Button -->
-  <notification-setting-button
-    :notificationData="notificationData || defaultNotificationData"
-    @openNotificationSettings="openNotificationSettings"
+  <div>
+    <!-- Notification Settings Button -->
+    <notification-setting-button
+      :notificationData="notificationData || defaultNotificationData"
+      @openNotificationSettings="openNotificationSettings"
     />
 
-  <!-- Notification Settings Popup-->
-  <notification-settings
-    :shopInfo="shopInfo"
-    :notificationData="notificationData"
-    :NotificationSettingsPopup="NotificationSettingsPopup"
-    @close="closeNotificationSettings"
-    v-if="notificationData"
+    <!-- Notification Settings Popup-->
+    <notification-settings
+      :shopInfo="shopInfo"
+      :notificationData="notificationData"
+      :NotificationSettingsPopup="NotificationSettingsPopup"
+      @close="closeNotificationSettings"
+      v-if="notificationData"
     />
-</div>
+  </div>
 </template>
 
 <script>
@@ -44,15 +44,20 @@ export default {
         uid: this.$store.getters.uidAdmin,
         createdAt: firestore.FieldValue.serverTimestamp()
       }
-    }
+    };
   },
   async created() {
-    const notification = await db
-      .doc(`restaurants/${this.restaurantId()}/private/notifications`)
-      .get();
-    this.notificationData = notification.exists
-      ? Object.assign(this.defaultNotificationData, notification.data())
-      : this.defaultNotificationData;
+    try {
+      const notification = await db
+        .doc(`restaurants/${this.restaurantId()}/private/notifications`)
+        .get();
+      this.notificationData = notification.exists
+        ? Object.assign(this.defaultNotificationData, notification.data())
+        : this.defaultNotificationData;
+    } catch (error) {
+      // We can ignore this error here
+      console.error(error.message);
+    }
   },
   methods: {
     openNotificationSettings() {
@@ -60,7 +65,7 @@ export default {
     },
     closeNotificationSettings() {
       this.NotificationSettingsPopup = false;
-    },
-  },
-}
+    }
+  }
+};
 </script>

--- a/src/app/admin/Notifications/Index.vue
+++ b/src/app/admin/Notifications/Index.vue
@@ -55,8 +55,12 @@ export default {
         ? Object.assign(this.defaultNotificationData, notification.data())
         : this.defaultNotificationData;
     } catch (error) {
-      // We can ignore this error here
-      console.error(error.message);
+      if (error.code === "permission-denied") {
+        // We can ignore this type of error here
+        console.warn("Ignoring", error.code);
+      } else {
+        throw error;
+      }
     }
   },
   methods: {

--- a/src/app/admin/QRCodePage.vue
+++ b/src/app/admin/QRCodePage.vue
@@ -23,7 +23,7 @@
             </div>
             <!-- Notification Settings -->
             <div class="level-right">
-              <notification-index :shopInfo="restaurant"/>
+              <notification-index :shopInfo="restaurant" />
             </div>
           </div>
         </div>

--- a/src/app/admin/Watcher/NewOrderWatcher.vue
+++ b/src/app/admin/Watcher/NewOrderWatcher.vue
@@ -1,5 +1,4 @@
-<template>
-</template>
+<template></template>
 
 <script>
 import { db, firestore } from "~/plugins/firebase.js";
@@ -8,20 +7,25 @@ import { order_status } from "~/plugins/constant.js";
 
 export default {
   props: {
-    notificationConfig: Object,
+    notificationConfig: Object
   },
   data() {
     return {
       order_detacher: () => {},
       orders: [],
       intervalTask: {},
-      intervalTime: 60, // (seconds)
-    }
+      intervalTime: 60 // (seconds)
+    };
   },
   async created() {
     this.dateWasUpdated();
     this.intervalTask = setInterval(() => {
-      console.log("newOrderWatcher: conf=" + this.notificationConfig.infinityNotification + " order=" + this.hasNewOrder);
+      console.log(
+        "newOrderWatcher: conf=" +
+          this.notificationConfig.infinityNotification +
+          " order=" +
+          this.hasNewOrder
+      );
       if (this.notificationConfig.infinityNotification && this.hasNewOrder) {
         this.soundPlay("NewOrderWatcher: play");
       }
@@ -54,12 +58,18 @@ export default {
         .collection(`restaurants/${this.restaurantId()}/orders`)
         .where("timePlaced", ">=", this.today)
         // .where("timePlaced", "<", this.tommorow)
-        .where("status", "==", order_status.order_placed).onSnapshot(result => {
-          this.orders = result.docs.map(this.doc2data("order"));
-          this.$store.commit("setOrders", this.orders);
-        });
-    },
+        .where("status", "==", order_status.order_placed)
+        .onSnapshot(
+          result => {
+            this.orders = result.docs.map(this.doc2data("order"));
+            this.$store.commit("setOrders", this.orders);
+          },
+          error => {
+            // We can ignore this error here
+            console.error(error.message);
+          }
+        );
+    }
   }
-}
-
+};
 </script>

--- a/src/app/admin/Watcher/NewOrderWatcher.vue
+++ b/src/app/admin/Watcher/NewOrderWatcher.vue
@@ -65,8 +65,12 @@ export default {
             this.$store.commit("setOrders", this.orders);
           },
           error => {
-            // We can ignore this error here
-            console.error(error.message);
+            if (error.code === "permission-denied") {
+              // We can ignore this type of error here
+              console.warn("Ignoring", error.code);
+            } else {
+              throw error;
+            }
           }
         );
     }

--- a/src/app/admin/Watcher/NotificationWatcher.vue
+++ b/src/app/admin/Watcher/NotificationWatcher.vue
@@ -1,5 +1,4 @@
-<template>
-</template>
+<template></template>
 
 <script>
 import { db, firestore } from "~/plugins/firebase.js";
@@ -10,28 +9,36 @@ export default {
       message_detacher: () => {},
       uid: this.$store.getters.uidAdmin,
       notifications: [],
-      watchingMessage: false,
-    }
+      watchingMessage: false
+    };
   },
   async created() {
     this.watchingMessage = false;
     this.message_detacher = db
       .doc(`admins/${this.uid}/private/notification`)
-      .onSnapshot(notification => {
-        if (notification.exists) {
-          const notification_data = notification.data();
-          this.notifications.push(notification_data);
-          if ((this.$route.path.indexOf(notification_data.path) > -1) &&
-              notification_data.sound && this.watchingMessage){
-            this.soundPlay("NotificationWatcher: newMessage");
+      .onSnapshot(
+        notification => {
+          if (notification.exists) {
+            const notification_data = notification.data();
+            this.notifications.push(notification_data);
+            if (
+              this.$route.path.indexOf(notification_data.path) > -1 &&
+              notification_data.sound &&
+              this.watchingMessage
+            ) {
+              this.soundPlay("NotificationWatcher: newMessage");
+            }
           }
+          this.watchingMessage = true;
+        },
+        error => {
+          // We can ignore this error here
+          console.error(error.message);
         }
-        this.watchingMessage = true;
-      });
+      );
   },
   destroyed() {
     this.message_detacher();
-  },
-}
-
+  }
+};
 </script>

--- a/src/app/admin/Watcher/NotificationWatcher.vue
+++ b/src/app/admin/Watcher/NotificationWatcher.vue
@@ -32,8 +32,12 @@ export default {
           this.watchingMessage = true;
         },
         error => {
-          // We can ignore this error here
-          console.error(error.message);
+          if (error.code === "permission-denied") {
+            // We can ignore this type of error here
+            console.warn("Ignoring", error.code);
+          } else {
+            throw error;
+          }
         }
       );
   },


### PR DESCRIPTION
権利のないユーザーがレストランページを開こうとした時に、Notification関連のコードのDBへのアクセスがエラーとして Sentry にレポートされてしまうので、エラーをcatchして、console にはエラー表示しながら、無視するように変更しました。