### PR TITLE
Present tip

### DIFF
--- a/src/app/admin/Order/OrderedInfo.vue
+++ b/src/app/admin/Order/OrderedInfo.vue
@@ -41,6 +41,12 @@
           <div>
             <i v-if="hasStripe" :class="'fab fa-cc-stripe stripe_'+order.payment.stripe"></i>
           </div>
+
+          <!-- Tip -->
+          <template v-if="order.tip">
+            <div class="t-body2 c-text-black-medium m-r-8 m-l-8">{{$t('order.tipShort')}}</div>
+            <div class="t-body2 c-text-black-high m-r-8">{{ $n(order.tip, 'currency') }}</div>
+          </template>
         </div>
       </div>
 

--- a/src/app/admin/OrderInfoPage.vue
+++ b/src/app/admin/OrderInfoPage.vue
@@ -68,6 +68,12 @@
                       <div v-else class="t-body1 c-textl-black-high is-inline-flex flex-center">
                         <div>{{$n(orderInfo.totalCharge, 'currency')}}</div>
                       </div>
+                      <div v-if="orderInfo.tip">
+                        <div class="t-caption c-text-black-medium">{{$t('order.tipShort')}}</div>
+                        <div
+                          class="t-body1 c-textl-black-high is-inline-flex flex-center"
+                        >{{$n(orderInfo.tip, 'currency')}}</div>
+                      </div>
                     </div>
                   </div>
                 </div>


### PR DESCRIPTION
レストランオーナー向けのオーダーの表示の際に、心付けの分を明示するようにしました。
場所としては二ヶ所あります。
- Order のリスト
- 個別 Order
