### PR TITLE
Update waring styles for Menu and Payment.

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -389,7 +389,8 @@
     },
     "viewPage": "View Page",
     "incompleteOrders": "{count} Incomplete Order | {count} Incomplete Orders",
-    "editMenuItems": "Edit Menu ({count})",
+    "editMenuItems": "Edit Menu: {count}",
+    "pleaseAddMenu": "Please Add Menu",
     "editAbout": "Edit Restaurant Details",
     "directory": {
       "status": "Restaurant Directory",
@@ -400,7 +401,7 @@
       "listed": "Listed",
       "unlist": "Unlist"
     },
-    "delete": "Delete",
+    "delete": "Delete This Restaurant",
     "shareRestaurant": "Share",
     "pleaseSignUp": "Sign Up as a New User",
     "forgotPassword": "Forgot Password？",

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -389,7 +389,8 @@
     },
     "viewPage": "ページを確認",
     "incompleteOrders": "{count} 個の未完了の注文",
-    "editMenuItems": "メニューの変更（{count}）",
+    "editMenuItems": "メニューの変更： {count}",
+    "pleaseAddMenu": "メニューを追加してください",
     "editAbout": "店情報の変更",
     "directory": {
       "status": "お客様向け飲食店一覧への掲載状況",
@@ -400,7 +401,7 @@
       "listed": "掲載済み",
       "unlist": "掲載を取り消す"
     },
-    "delete": "削除",
+    "delete": "この飲食店を削除",
     "shareRestaurant": "シェア",
     "pleaseSignUp": "新規ユーザー登録",
     "forgotPassword": "パスワードを忘れた場合",

--- a/src/app/admin/Index.vue
+++ b/src/app/admin/Index.vue
@@ -108,6 +108,22 @@
       <div class="column is-narrow w-24"></div>
     </div>
 
+    <!-- Unset Warning -->
+    <div class="columns is-gapless" v-if="unsetWarning">
+      <!-- Left Gap -->
+      <div class="column is-narrow w-24"></div>
+      <!-- Center Column -->
+      <div class="column">
+        <div class="m-l-24 m-r-24">
+          <div class="bg-status-red-bg r-8 p-l-16 p-r-16 p-t-16 p-b-16 l m-b-8 m-t-24">
+            <span class="t-body2 c-status-red">{{ $t("admin.payments.unsetWarning") }}</span>
+          </div>
+        </div>
+      </div>
+      <!-- Right Gap -->
+      <div class="column is-narrow w-24"></div>
+    </div>
+
     <!-- Payment Setup and Restaurants -->
     <div class="columns is-gapless">
       <!-- Left Gap -->
@@ -237,7 +253,8 @@ export default {
       restaurantItems: null,
       detachers: [],
       restaurant_detacher: null,
-      news: newsList[0]
+      news: newsList[0],
+      unsetWarning: true
     };
   },
   created() {

--- a/src/app/admin/Payment/PaymentSection.vue
+++ b/src/app/admin/Payment/PaymentSection.vue
@@ -2,14 +2,6 @@
   <div class="m-t-24">
     <div class="t-h6 c-text-black-disabled m-b-8">{{ $t("admin.payment") }}</div>
 
-    <!-- Unset Warning -->
-    <div
-      v-if="!inStorePayment && !hasStripe"
-      class="bg-status-red-bg r-8 p-l-16 p-r-16 p-t-16 p-b-16 l m-b-8"
-    >
-      <span class="t-body2 c-status-red">{{ $t("admin.payments.unsetWarning") }}</span>
-    </div>
-
     <div class="bg-surface r-8 d-low p-t-24 p-b-24" :style="cardStyle">
       <!-- Online Payment -->
       <div class="m-l-24 m-r-24">
@@ -182,7 +174,6 @@ export default {
     redirectURI() {
       return `${location.protocol}//${location.host}${location.pathname}`;
     },
-
     hasStripe() {
       return !!this.paymentInfo.stripe;
     },

--- a/src/app/admin/Restaurant/RestaurantEditCard.vue
+++ b/src/app/admin/Restaurant/RestaurantEditCard.vue
@@ -47,18 +47,34 @@
 
       <!-- Edit Menu -->
       <div class="align-center m-t-24">
-        <b-button
-          tag="nuxt-link"
-          :to="'/admin/restaurants/' + restaurantid + '/menus'"
-          style="min-width: 256px;"
-          class="op-button-small secondary"
-        >
-          <span class="c-primary p-l-24 p-r-24">
-            {{
-            $t("admin.editMenuItems", { count: numberOfMenus })
-            }}
-          </span>
-        </b-button>
+        <!-- Menu Not Existing -->
+        <div v-if="numberOfMenus == 0">
+          <b-button
+            tag="nuxt-link"
+            :to="'/admin/restaurants/' + restaurantid + '/menus'"
+            style="min-width: 256px; border-color: #b00020;"
+            class="op-button-small secondary"
+          >
+            <span
+              class="c-status-red p-l-24 p-r-24"
+            >{{ $t("admin.editMenuItems", { count: numberOfMenus }) }}</span>
+          </b-button>
+          <div class="t-body2 c-status-red m-t-4">{{ $t("admin.pleaseAddMenu") }}</div>
+        </div>
+
+        <!-- Menu Existing -->
+        <div v-else>
+          <b-button
+            tag="nuxt-link"
+            :to="'/admin/restaurants/' + restaurantid + '/menus'"
+            style="min-width: 256px;"
+            class="op-button-small secondary"
+          >
+            <span
+              class="c-primary p-l-24 p-r-24"
+            >{{ $t("admin.editMenuItems", { count: numberOfMenus }) }}</span>
+          </b-button>
+        </div>
       </div>
 
       <!-- Edit Restaurant Details -->


### PR DESCRIPTION
オーナーホームの警告スタイルをアップデートしました（メニュー0の場合とお支払い未設定の場合）。
お支払い未設定の場合は`v-if="unsetWarning"`を設定していますが、子コンポーネントの`PaymentSection.vue`から`!this.inStorePayment && !this.hasStripe`を受け取る必要がありますので実装の方よろしくお願いいたします。