### PR TITLE
List of "liked" restaurants

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -183,7 +183,8 @@
   "find": {
     "area": "Areas",
     "areaAll": "All Areas",
-    "areaTop": "Areas Top"
+    "areaTop": "Areas Top",
+    "likes": "Likes"
   },
   "shopInfo": {
     "thisIsPreview": "This is Preview Only.",

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -183,7 +183,8 @@
   "find": {
     "area": "飲食店エリア",
     "areaAll": "全てのエリア",
-    "areaTop": "エリア一覧"
+    "areaTop": "エリア一覧",
+    "likes": "お気に入り"
   },
   "shopInfo": {
     "thisIsPreview": "これは飲食店向けプレビューです。",

--- a/src/app/user/Restaurant/SharePopup.vue
+++ b/src/app/user/Restaurant/SharePopup.vue
@@ -107,7 +107,8 @@ export default {
       db.doc(`users/${this.user.uid}/reviews/${this.restaurantId()}`).set(
         {
           likes: !this.likes,
-          restaurantName: this.shopInfo.restaurantName, // for quick display
+          restaurantName: this.shopInfo.restaurantName, // duplicated for quick display
+          restProfilePhoto: this.shopInfo.restProfilePhoto, // duplicated for quick display
           timeLiked: firestore.FieldValue.serverTimestamp(),
           restaurantId: this.restaurantId() // Making it possible to collection query (later)
         },

--- a/src/app/user/Restaurant/SharePopup.vue
+++ b/src/app/user/Restaurant/SharePopup.vue
@@ -85,6 +85,23 @@ export default {
         .doc(`users/${this.user.uid}/reviews/${this.restaurantId()}`)
         .onSnapshot(snapshot => {
           this.review = snapshot.data() || {};
+          if (this.review.restaurantName) {
+            // Check if the cached info is out of date, update them.
+            if (
+              this.review.restaurantName !== this.shopInfo.restaurantName ||
+              this.review.restProfilePhoto != this.shopInfo.restProfilePhoto
+            ) {
+              db.doc(
+                `users/${this.user.uid}/reviews/${this.restaurantId()}`
+              ).set(
+                {
+                  restaurantName: this.shopInfo.restaurantName, // duplicated for quick display
+                  restProfilePhoto: this.shopInfo.restProfilePhoto // duplicated for quick display
+                },
+                { merge: true }
+              );
+            }
+          }
         });
     }
   },
@@ -104,6 +121,7 @@ export default {
       this.sharePopup = false;
     },
     handleLike() {
+      // Notice that mounted() will automatically update duplicated restaurant info.
       db.doc(`users/${this.user.uid}/reviews/${this.restaurantId()}`).set(
         {
           likes: !this.likes,

--- a/src/app/user/Restaurant/SharePopup.vue
+++ b/src/app/user/Restaurant/SharePopup.vue
@@ -55,7 +55,7 @@
 
 <script>
 import SharingButtons from "~/app/user/Common/SharingButtons";
-import { db } from "~/plugins/firebase.js";
+import { db, firestore } from "~/plugins/firebase.js";
 
 export default {
   components: {
@@ -107,6 +107,8 @@ export default {
       db.doc(`users/${this.user.uid}/reviews/${this.restaurantId()}`).set(
         {
           likes: !this.likes,
+          restaurantName: this.shopInfo.restaurantName, // for quick display
+          timeLiked: firestore.FieldValue.serverTimestamp(),
           restaurantId: this.restaurantId() // Making it possible to collection query (later)
         },
         { merge: true }

--- a/src/app/user/RootPage.vue
+++ b/src/app/user/RootPage.vue
@@ -40,7 +40,7 @@
       <div class="column is-narrow w-24"></div>
     </div>
     <!-- Likes -->
-    <div v-if="likes.length > 0" class="m-l-48 m-t-8">
+    <div v-if="likes.length > 0" class="m-l-24 m-t-8">
       <!-- Title -->
       <div class="t-h6 c-text-black-disabled m-t-24">{{$t("find.likes")}}</div>
       <div v-for="like in likes" :key="like.restaurantId" class="m-t-8">

--- a/src/app/user/RootPage.vue
+++ b/src/app/user/RootPage.vue
@@ -44,7 +44,25 @@
       <!-- Title -->
       <div class="t-h6 c-text-black-disabled m-t-24">{{$t("find.likes")}}</div>
       <div v-for="like in likes" :key="like.restaurantId" class="m-t-8">
-        <nuxt-link :to="`/r/${like.restaurantId}`">{{ like.restaurantName }}</nuxt-link>
+        <div class="h-full p-b-8 p-r-8">
+          <router-link :to="`/r/${like.restaurantId}`">
+            <div class="touchable h-full">
+              <div class="cols flex-center">
+                <!-- Restaurant Profile -->
+                <div class="m-r-16 h-48">
+                  <img :src="like.restProfilePhoto" class="w-48 h-48 r-48 cover" />
+                </div>
+
+                <!-- Restaurant Name -->
+                <div class="flex-1 p-r-8 t-subtitle1 c-primary">
+                  {{
+                  like.restaurantName
+                  }}
+                </div>
+              </div>
+            </div>
+          </router-link>
+        </div>
       </div>
     </div>
   </div>

--- a/src/app/user/RootPage.vue
+++ b/src/app/user/RootPage.vue
@@ -123,7 +123,6 @@ export default {
         .orderBy("timeLiked", "desc")
         .limit(100)
         .get();
-      console.log(snapshot);
       this.likes = (snapshot.docs || []).map(doc => {
         return doc.data();
       });

--- a/src/app/user/RootPage.vue
+++ b/src/app/user/RootPage.vue
@@ -39,6 +39,14 @@
       <!-- Right Gap -->
       <div class="column is-narrow w-24"></div>
     </div>
+    <!-- Likes -->
+    <div v-if="likes.length > 0" class="m-l-48 m-t-8">
+      <!-- Title -->
+      <div class="t-h6 c-text-black-disabled m-t-24">{{$t("find.likes")}}</div>
+      <div v-for="like in likes" :key="like.restaurantId" class="m-t-8">
+        <nuxt-link :to="`/r/${like.restaurantId}`">{{ like.restaurantName }}</nuxt-link>
+      </div>
+    </div>
   </div>
 </template>
 
@@ -56,26 +64,43 @@ export default {
     return {
       // # Need to rewrite for Areas instead of Restaurants.
       region: ownPlateConfig.region,
+      likes: [],
       restaurants: [],
       areas:
         ownPlateConfig.region == "JP"
           ? [
-            { name: "東京都", id: 12 },
-            { name: "群馬県", id: 9  },
-            { name: "埼玉県", id: 10 },
-            { name: "福岡県", id: 39 },
-            { name: "福井県", id: 17 },
-            { name: "大阪府", id: 26 },
-            { name: "兵庫県", id: 27 },
-            { name: "広島県", id: 33 },
-            { name: "長崎県", id: 41 }
-          ]
+              { name: "東京都", id: 12 },
+              { name: "群馬県", id: 9 },
+              { name: "埼玉県", id: 10 },
+              { name: "福岡県", id: 39 },
+              { name: "福井県", id: 17 },
+              { name: "大阪府", id: 26 },
+              { name: "兵庫県", id: 27 },
+              { name: "広島県", id: 33 },
+              { name: "長崎県", id: 41 }
+            ]
           : [{ name: "Washington", id: 46 }]
     };
   },
   head() {
-    const title = [this.$t("pageTitle.restaurantRoot"), ownPlateConfig.siteName].join(" / ")
-    return Object.assign(RestaurantHeader, {title});
+    const title = [
+      this.$t("pageTitle.restaurantRoot"),
+      ownPlateConfig.siteName
+    ].join(" / ");
+    return Object.assign(RestaurantHeader, { title });
+  },
+  async mounted() {
+    if (this.isUser) {
+      const snapshot = await db
+        .collection(`users/${this.user.uid}/reviews`)
+        .orderBy("timeLiked", "desc")
+        .limit(100)
+        .get();
+      console.log(snapshot);
+      this.likes = (snapshot.docs || []).map(doc => {
+        return doc.data();
+      });
+    }
   }
   // # Need to rewrite for Areas instead of Restaurants.
   /*

--- a/src/app/user/RootPage.vue
+++ b/src/app/user/RootPage.vue
@@ -39,31 +39,40 @@
       <!-- Right Gap -->
       <div class="column is-narrow w-24"></div>
     </div>
-    <!-- Likes -->
-    <div v-if="likes.length > 0" class="m-l-24 m-t-8">
-      <!-- Title -->
-      <div class="t-h6 c-text-black-disabled m-t-24">{{$t("find.likes")}}</div>
-      <div v-for="like in likes" :key="like.restaurantId" class="m-t-8">
-        <div class="h-full p-b-8 p-r-8">
-          <router-link :to="`/r/${like.restaurantId}`">
-            <div class="touchable h-full">
-              <div class="cols flex-center">
-                <!-- Restaurant Profile -->
-                <div class="m-r-16 h-48">
-                  <img :src="like.restProfilePhoto" class="w-48 h-48 r-48 cover" />
-                </div>
+    <!-- Likes Header Area -->
+    <div class="columns is-gapless" v-if="likes.length > 0">
+      <!-- Left Gap -->
+      <div class="column is-narrow w-24"></div>
+      <!-- Center Column -->
+      <div class="column">
+        <div class="m-l-24 m-r-24 m-t-24">
+          <!-- Title -->
+          <div class="t-h6 c-text-black-disabled m-t-24">{{$t("find.likes")}}</div>
+          <div v-for="like in likes" :key="like.restaurantId" class="m-t-8">
+            <div class="h-full p-b-8 p-r-8">
+              <router-link :to="`/r/${like.restaurantId}`">
+                <div class="touchable h-full">
+                  <div class="cols flex-center">
+                    <!-- Restaurant Profile -->
+                    <div class="m-r-16 h-48">
+                      <img :src="like.restProfilePhoto" class="w-48 h-48 r-48 cover" />
+                    </div>
 
-                <!-- Restaurant Name -->
-                <div class="flex-1 p-r-8 t-subtitle1 c-primary">
-                  {{
-                  like.restaurantName
-                  }}
+                    <!-- Restaurant Name -->
+                    <div class="flex-1 p-r-8 t-subtitle1 c-primary">
+                      {{
+                      like.restaurantName
+                      }}
+                    </div>
+                  </div>
                 </div>
-              </div>
+              </router-link>
             </div>
-          </router-link>
+          </div>
         </div>
       </div>
+      <!-- Right Gap -->
+      <div class="column is-narrow w-24"></div>
     </div>
   </div>
 </template>


### PR DESCRIPTION
飲食店エリアの下にお気に入りのレストランを表示するようにしました。
query の回数を減らすために、レストラン名とサムネは review ドキュメントにコピーしています。
そのコピーが古くなった場合には、レストランのページを開いたときにアップデートします。