### PR TITLE
Super logging

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -45,6 +45,28 @@
   ],
   "fieldOverrides": [
     {
+      "collectionGroup": "adminlogs",
+      "fieldPath": "createdAt",
+      "indexes": [
+        {
+          "order": "ASCENDING",
+          "queryScope": "COLLECTION"
+        },
+        {
+          "order": "DESCENDING",
+          "queryScope": "COLLECTION"
+        },
+        {
+          "arrayConfig": "CONTAINS",
+          "queryScope": "COLLECTION"
+        },
+        {
+          "order": "DESCENDING",
+          "queryScope": "COLLECTION_GROUP"
+        }
+      ]
+    },
+    {
       "collectionGroup": "orders",
       "fieldPath": "status",
       "indexes": [

--- a/firestore.rules
+++ b/firestore.rules
@@ -90,7 +90,7 @@ service cloud.firestore {
     match /{path=**}/private/{documentId} {
       allow read: if isSuper(request);
     }
-    match /{path=**}/logs/{documentId} {
+    match /{path=**}/adminlogs/{documentId} {
       allow read: if isSuper(request);
     }
 

--- a/firestore.rules
+++ b/firestore.rules
@@ -90,6 +90,9 @@ service cloud.firestore {
     match /{path=**}/private/{documentId} {
       allow read: if isSuper(request);
     }
+    match /{path=**}/logs/{documentId} {
+      allow read: if isSuper(request);
+    }
 
     match /restaurants {
       match /{restaurantId} {

--- a/functions/src/functions/super.ts
+++ b/functions/src/functions/super.ts
@@ -20,14 +20,28 @@ export const dispatch = async (db: FirebaseFirestore.Firestore, data: any, conte
         const userRecord = await admin.auth().getUser(uid);
         if (key === "operator" && userRecord.email) {
           result = await setCustomClaim(db, uid, key, value);
-          await db.collection(`admins/${uidSuper}/logs`).add({
-            admin: true,
+          await db.collection(`admins/${uidSuper}/adminlogs`).add({
             uid, uidSuper, cmd, key, value,
+            email: userRecord.email,
+            success: true,
+            createdAt: admin.firestore.Timestamp.now()
+          })
+        } else {
+          await db.collection(`admins/${uidSuper}/adminlogs`).add({
+            uid, uidSuper, cmd, key, value,
+            success: false,
+            error: "invalid_parameters",
             createdAt: admin.firestore.Timestamp.now()
           })
         }
         break;
       default:
+        await db.collection(`admins/${uidSuper}/adminlogs`).add({
+          uid, uidSuper, cmd, key, value,
+          success: false,
+          error: "invalid_cmd",
+          createdAt: admin.firestore.Timestamp.now()
+        })
         throw new functions.https.HttpsError('invalid-argument', 'Invalid command.')
     }
 

--- a/functions/src/functions/super.ts
+++ b/functions/src/functions/super.ts
@@ -6,6 +6,7 @@ export const dispatch = async (db: FirebaseFirestore.Firestore, data: any, conte
   if (!context.auth?.token?.admin) {
     throw new functions.https.HttpsError('permission-denied', 'You do not have permission to confirm this request.')
   }
+  const uidSuper = utils.validate_auth(context);
   const { cmd, uid, key, value } = data;
   utils.validate_params({ cmd, uid });
 
@@ -19,6 +20,11 @@ export const dispatch = async (db: FirebaseFirestore.Firestore, data: any, conte
         const userRecord = await admin.auth().getUser(uid);
         if (key === "operator" && userRecord.email) {
           result = await setCustomClaim(db, uid, key, value);
+          await db.collection(`admins/${uidSuper}/logs`).add({
+            admin: true,
+            uid, uidSuper, cmd, key, value,
+            createdAt: admin.firestore.Timestamp.now()
+          })
         }
         break;
       default:

--- a/functions/src/functions/super.ts
+++ b/functions/src/functions/super.ts
@@ -16,7 +16,7 @@ export const dispatch = async (db: FirebaseFirestore.Firestore, data: any, conte
       case "getCustomeClaims":
         result = await getCustomClaims(db, uid);
         break;
-      case "setCustomeClaim":
+      case "setCustomClaim":
         const userRecord = await admin.auth().getUser(uid);
         if (key === "operator" && userRecord.email) {
           result = await setCustomClaim(db, uid, key, value);

--- a/src/app/super/AdminInfo.vue
+++ b/src/app/super/AdminInfo.vue
@@ -40,7 +40,7 @@ export default {
         this.$store.commit("setLoading", true);
         try {
           const { data } = await this.superDispatch({
-            cmd: "setCustomeClaim",
+            cmd: "setCustomClaim",
             uid: this.adminId,
             key: "operator",
             value: value

--- a/src/app/super/AllLogs.vue
+++ b/src/app/super/AllLogs.vue
@@ -4,9 +4,13 @@
     <h2>All Logs</h2>
     <table>
       <tr v-for="log in logs" :key="log.id">
-        <td>{{ log.cmd }} {{log.key}} {{log.value}}</td>
-        <td>{{log.email}}</td>
-        <td>{{log.uidSuper}}</td>
+        <td class="p-b-4">
+          {{ log.cmd }}
+          <div class="m-l-8">{{log.key}} {{log.value}}</div>
+        </td>
+        <td class="p-l-8">{{log.success ? "success": log.error}}</td>
+        <td class="p-l-8">{{log.email || log.uid}}</td>
+        <td class="p-l-8">{{log.uidSuper.slice(0,8) + "..."}}</td>
       </tr>
     </table>
   </section>
@@ -43,7 +47,6 @@ export default {
           log.createdAt = log.createdAt.toDate();
           return log;
         });
-        console.log("***", this.logs);
       });
   },
   destroyed() {

--- a/src/app/super/AllLogs.vue
+++ b/src/app/super/AllLogs.vue
@@ -1,0 +1,47 @@
+<template>
+  <section class="section">
+    <back-button url="/s" />
+    <h2>All Logs</h2>
+  </section>
+</template>
+
+<script>
+import BackButton from "~/components/BackButton";
+import { db } from "~/plugins/firebase.js";
+
+export default {
+  components: {
+    BackButton
+  },
+  data() {
+    return {
+      logs: [],
+      detacher: null
+    };
+  },
+  async mounted() {
+    if (!this.$store.state.user || this.$store.getters.isNotSuperAdmin) {
+      this.$router.push("/");
+    }
+  },
+  created() {
+    this.detatcher = db
+      .collectionGroup("logs")
+      .orderBy("createdAt", "desc")
+      .where("admin", "==", true)
+      .limit(100)
+      .onSnapshot(snapshot => {
+        this.logs = snapshot.docs.map(doc => {
+          const log = doc.data();
+          log.id = doc.id;
+          log.createdAt = log.createdAt.toDate();
+          return log;
+        });
+        console.log("***", this.logs);
+      });
+  },
+  destroyed() {
+    this.detatcher && this.detatcher();
+  }
+};
+</script>

--- a/src/app/super/AllLogs.vue
+++ b/src/app/super/AllLogs.vue
@@ -2,6 +2,12 @@
   <section class="section">
     <back-button url="/s" />
     <h2>All Logs</h2>
+    <table>
+      <tr v-for="log in logs" :key="log.id">
+        <td>{{ log.cmd }} {{log.key}} {{log.value}}</td>
+        <td>{{log.uid}} {{log.uidSuper}}</td>
+      </tr>
+    </table>
   </section>
 </template>
 

--- a/src/app/super/AllLogs.vue
+++ b/src/app/super/AllLogs.vue
@@ -5,7 +5,8 @@
     <table>
       <tr v-for="log in logs" :key="log.id">
         <td>{{ log.cmd }} {{log.key}} {{log.value}}</td>
-        <td>{{log.uid}} {{log.uidSuper}}</td>
+        <td>{{log.email}}</td>
+        <td>{{log.uidSuper}}</td>
       </tr>
     </table>
   </section>
@@ -32,9 +33,8 @@ export default {
   },
   created() {
     this.detatcher = db
-      .collectionGroup("logs")
+      .collectionGroup("adminlogs")
       .orderBy("createdAt", "desc")
-      .where("admin", "==", true)
       .limit(100)
       .onSnapshot(snapshot => {
         this.logs = snapshot.docs.map(doc => {

--- a/src/app/super/Index.vue
+++ b/src/app/super/Index.vue
@@ -14,6 +14,8 @@
       <br />
       <router-link to="/s/profiles">All Profiles</router-link>
       <br />
+      <router-link to="/s/logs">All Logs</router-link>
+      <br />
     </div>
     <b-loading v-else active />
   </section>

--- a/src/routes.js
+++ b/src/routes.js
@@ -158,6 +158,10 @@ export const customRoutes = [
     component: "super/AllAdmins.vue"
   },
   {
+    path: "/s/logs",
+    component: "super/AllLogs.vue"
+  },
+  {
     path: "/s/profiles",
     component: "super/Profiles.vue"
   },


### PR DESCRIPTION
Super admin による操作（データベースの変更など）のログを残す仕組みです。
- ログは /admins/{uidSuper}/logs 以下に記録されます（super admin ごと）
- 表示の際には、collection group query を使います
- super admin の操作であることを示す admin フラグを立てています
- admin の uid でサーチできるように、ドキュメントに uidSuper を追加しています 
- cmd にどんなログなのかが文字列で入っています
- setCustomClaim の場合には、uid, key, value を格納していますが、他のログの場合には別のデータを格納することになると思います。
- 表示は cmd ごとに変えることになると思います
- setCustomClaims にタイポがあったので修正しました（ログを取る前なので、後方互換は不要です）。