### PR TITLE
order details

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -268,6 +268,7 @@
     "inclusiveTax": "Sales Tax (inclusive)",
     "total": "Total",
     "yourPayment": "Your Payment",
+    "details": "Details",
     "reuseCard": "Save it for future use",
     "whatsCVC": "What’s CVC?",
     "no_jcb": "＊This restaurant does not accept JCB card",

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -268,6 +268,7 @@
     "inclusiveTax": "消費税（内税）",
     "total": "合計",
     "yourPayment": "お支払い",
+    "details": "明細",
     "reuseCard": "今後の支払いのために保存する",
     "whatsCVC": "CVCとは？",
     "no_jcb": "＊このお店では、JCBカードは使えません",

--- a/src/app/admin/OrderInfoPage.vue
+++ b/src/app/admin/OrderInfoPage.vue
@@ -201,6 +201,11 @@
               <!-- Order Items -->
               <ordered-item v-for="id in ids" :key="id" :item="items[id]" />
             </div>
+            <div class="m-t-24">
+              <!-- Details -->
+              <div class="t-h6 c-text-black-disabled">{{ $t("order.details") }}</div>
+              <order-info :orderItems="this.orderItems" :orderInfo="this.orderInfo || {}"></order-info>
+            </div>
           </div>
         </div>
         <!-- Right Gap -->
@@ -227,12 +232,14 @@ import NotFound from "~/components/NotFound";
 import { ownPlateConfig } from "~/config/project";
 import NotificationIndex from "./Notifications/Index";
 import { formatOption } from "~/plugins/strings.js";
+import OrderInfo from "~/app/user/Order/OrderInfo";
 
 export default {
   components: {
     BackButton,
     OrderedItem,
     NotificationIndex,
+    OrderInfo,
     NotFound
   },
 
@@ -290,6 +297,21 @@ export default {
     });
   },
   computed: {
+    orderItems() {
+      if (this.orderInfo.order && this.orderInfo.menuItems) {
+        return Object.keys(this.orderInfo.order).map(key => {
+          const num = this.orderInfo.order[key];
+          return {
+            item: this.orderInfo.menuItems[key],
+            count: num,
+            id: key,
+            options:
+              (this.orderInfo.options && this.orderInfo.options[key]) || []
+          };
+        });
+      }
+      return [];
+    },
     search() {
       const value = encodeURIComponent(
         this.orderInfo.description || this.orderName


### PR DESCRIPTION
レストラン向けの個別オーダーページに、明細を追加しました。
ユーザー向けのオーダーページで使っているのと同じものです。
情報が重複しますが、キッチンで注文を裁く場合には、注文の内容が大きく写真入りで表示された方が良いので、そのままにしています。