### PR TITLE
All orders

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -449,7 +449,8 @@
       "lineAdd": "Add a LINE account",
       "lineUsers": "Connected LINE Accounts",
       "lineDelete": "Do you really want to delete this account？",
-      "lineSafariPrivate": "Note: If you are using Safari's Private Browsing Mode, you will not be able to connect to LINE."
+      "lineSafariPrivate": "Note: If you are using Safari's Private Browsing Mode, you will not be able to connect to LINE.",
+      "history": "注文履歴"
     },
     "sound": {
       "default": "Default",

--- a/lang/en.json
+++ b/lang/en.json
@@ -450,7 +450,8 @@
       "lineUsers": "Connected LINE Accounts",
       "lineDelete": "Do you really want to delete this account？",
       "lineSafariPrivate": "Note: If you are using Safari's Private Browsing Mode, you will not be able to connect to LINE.",
-      "history": "注文履歴"
+      "history": "Order History",
+      "more": "More"
     },
     "sound": {
       "default": "Default",

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -449,7 +449,8 @@
       "lineAdd": "LINEアカウントの追加",
       "lineUsers": "登録済みLINEアカウント",
       "lineDelete": "本当に消去しますか？",
-      "lineSafariPrivate": "注意: Safariのプライベートブラウズモードを使用しているとLINE連携ができません。"
+      "lineSafariPrivate": "注意: Safariのプライベートブラウズモードを使用しているとLINE連携ができません。",
+      "history": "注文履歴"
     },
     "sound": {
       "default": "ピコリン",

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -450,7 +450,8 @@
       "lineUsers": "登録済みLINEアカウント",
       "lineDelete": "本当に消去しますか？",
       "lineSafariPrivate": "注意: Safariのプライベートブラウズモードを使用しているとLINE連携ができません。",
-      "history": "注文履歴"
+      "history": "注文履歴",
+      "more": "もっと見る"
     },
     "sound": {
       "default": "ピコリン",

--- a/src/app/admin/OrderHistory.vue
+++ b/src/app/admin/OrderHistory.vue
@@ -44,13 +44,6 @@
               <notification-index :shopInfo="shopInfo" />
             </div>
           </div>
-
-          <!-- Date and Sound -->
-          <div class="level">
-            <!-- Select Date -->
-            <div class="level-left"></div>
-            <div class="level-right"></div>
-          </div>
         </div>
       </div>
       <!-- Right Gap -->
@@ -74,7 +67,7 @@
               :isSuperView="true"
             />
           </div>
-          <div class="m-t-24">
+          <div class="m-t-24" v-if="last !== undefined">
             <b-button class="b-reset h-36 r-36 bg-form" :disabled="last === null" @click="next">
               <span class="p-l-16 p-r-16">{{ $t('admin.order.more') }}</span>
             </b-button>

--- a/src/app/admin/OrderHistory.vue
+++ b/src/app/admin/OrderHistory.vue
@@ -71,10 +71,13 @@
               :key="order.id"
               @selected="orderSelected($event)"
               :order="order"
+              :isSuperView="true"
             />
           </div>
           <div class="m-t-24">
-            <b-button :disabled="last === null" @click="next">{{ $t('admin.order.more') }}</b-button>
+            <b-button class="b-reset h-36 r-36 bg-form" :disabled="last === null" @click="next">
+              <span class="p-l-16 p-r-16">{{ $t('admin.order.more') }}</span>
+            </b-button>
           </div>
         </div>
       </div>
@@ -133,7 +136,6 @@ export default {
       const docs = (await query.get()).docs;
       this.last = docs.length == this.limit ? docs[this.limit - 1] : null;
       const orders = docs.map(this.doc2data("order"));
-      console.log(orders);
       orders.forEach(order => {
         order.timePlaced = order.timePlaced.toDate();
         if (order.timeEstimated) {

--- a/src/app/admin/OrderHistory.vue
+++ b/src/app/admin/OrderHistory.vue
@@ -1,0 +1,232 @@
+<template>
+  <div>
+    <!-- Order Header Area -->
+    <div class="columns is-gapless">
+      <!-- Left Gap -->
+      <div class="column is-narrow w-24"></div>
+      <!-- Center Column -->
+      <div class="column">
+        <div class="m-l-24 m-r-24">
+          <!-- Nav Bar -->
+          <div class="level">
+            <!-- Back Button and Restaurant Profile -->
+            <div class="level-left flex-1">
+              <!-- Back Button -->
+              <back-button url="/admin/restaurants/" class="m-t-24 m-r-16" />
+
+              <!-- Restaurant Profile -->
+              <div class="is-inline-flex flex-center m-t-24">
+                <div>
+                  <img :src="shopInfo.restProfilePhoto" class="w-36 h-36 r-36 cover" />
+                </div>
+                <div class="t-h6 c-text-black-high m-l-8 flex-1">{{ shopInfo.restaurantName }}</div>
+              </div>
+            </div>
+
+            <!-- Suspend and Notification -->
+            <div class="level-right">
+              <!-- Suspend Button -->
+              <b-button
+                tag="nuxt-link"
+                :to="`/admin/restaurants/${restaurantId()}/suspend`"
+                class="b-reset op-button-pill h-36 bg-form m-t-24 m-r-16"
+              >
+                <i class="material-icons c-primary m-l-8">remove_shopping_cart</i>
+                <span class="c-primary t-button">{{ $t("admin.order.suspend") }}</span>
+                <!-- # ToDO: Show number of suspended items. -->
+                <span class="t-button c-status-red">0</span>
+              </b-button>
+
+              <!-- Notification Settings -->
+              <notification-index :shopInfo="shopInfo" />
+            </div>
+          </div>
+
+          <!-- Date and Sound -->
+          <div class="level">
+            <!-- Select Date -->
+            <div class="level-left">
+              <b-select v-model="dayIndex" class="m-t-24">
+                <option v-for="day in lastSeveralDays" :value="day.index" :key="day.index">
+                  {{ $d(day.date, "short") }} {{ orderCounter[moment(day.date).format("YYYY-MM-DD")] }}
+                  <span
+                    v-if="day.index === pickUpDaysInAdvance"
+                  >{{ $t("date.today") }}</span>
+                </option>
+              </b-select>
+            </div>
+
+            <div class="level-right"></div>
+          </div>
+        </div>
+      </div>
+      <!-- Right Gap -->
+      <div class="column is-narrow w-24"></div>
+    </div>
+
+    <!-- Order Body Area -->
+    <div class="columns is-gapless">
+      <!-- Left Gap -->
+      <div class="column is-narrow w-24"></div>
+      <!-- Center Column -->
+      <div class="column">
+        <div class="m-l-24 m-r-16 m-t-24">
+          <!-- Orders -->
+          <div class="columns is-gapless is-multiline">
+            <ordered-info
+              v-for="order in orders"
+              :key="order.id"
+              @selected="orderSelected($event)"
+              :order="order"
+            />
+          </div>
+        </div>
+      </div>
+      <!-- Right Gap -->
+      <div class="column is-narrow w-24"></div>
+    </div>
+  </div>
+</template>
+
+<script>
+import { db, firestore } from "~/plugins/firebase.js";
+import { midNight } from "~/plugins/dateUtils.js";
+import OrderedInfo from "~/app/admin/Order/OrderedInfo";
+import BackButton from "~/components/BackButton";
+import { order_status } from "~/plugins/constant.js";
+import moment from "moment";
+
+import NotificationIndex from "./Notifications/Index";
+
+export default {
+  components: {
+    OrderedInfo,
+    BackButton,
+    NotificationIndex
+  },
+  data() {
+    return {
+      shopInfo: {},
+      orders: [],
+      dayIndex: 0,
+      order_detacher: () => {}
+    };
+  },
+  watch: {
+    dayIndex() {
+      this.updateQueryDay();
+      this.dateWasUpdated();
+    },
+    "$route.query.day"() {
+      this.updateDayIndex();
+    }
+  },
+  async created() {
+    this.checkAdminPermission();
+    const restaurantDoc = await db
+      .doc(`restaurants/${this.restaurantId()}`)
+      .get();
+    if (!restaurantDoc.exists) {
+      // todo not found
+      return;
+    }
+    this.shopInfo = restaurantDoc.data();
+    this.dayIndex = this.getPickUpDaysInAdvance();
+
+    if (this.$route.query.day) {
+      this.updateDayIndex();
+    }
+    this.dateWasUpdated();
+  },
+  destroyed() {
+    this.order_detacher();
+  },
+  computed: {
+    orderCounter() {
+      return this.lastSeveralDays.reduce((tmp, day) => {
+        const count = (
+          this.$store.state.orderObj[moment(day.date).format("YYYY-MM-DD")] ||
+          []
+        ).length;
+        if (count > 0) {
+          tmp[moment(day.date).format("YYYY-MM-DD")] = "(" + count + ")";
+        }
+        return tmp;
+      }, {});
+    },
+    pickUpDaysInAdvance() {
+      return this.getPickUpDaysInAdvance();
+    },
+    lastSeveralDays() {
+      return Array.from(Array(10 + this.pickUpDaysInAdvance).keys()).map(
+        index => {
+          const date = midNight(this.pickUpDaysInAdvance - index);
+          return { index, date };
+        }
+      );
+    }
+  },
+  methods: {
+    updateDayIndex() {
+      const dayIndex =
+        this.lastSeveralDays.findIndex(day => {
+          return (
+            moment(day.date).format("YYYY-MM-DD") === this.$route.query.day
+          );
+        }) || 0;
+      this.dayIndex = dayIndex > 0 ? dayIndex : 0;
+    },
+    updateQueryDay() {
+      const day = moment(this.lastSeveralDays[this.dayIndex].date).format(
+        "YYYY-MM-DD"
+      );
+      this.$router.push({
+        path: "/admin/restaurants/" + this.restaurantId() + "/orders?day=" + day
+      });
+    },
+    dateWasUpdated() {
+      this.order_detacher();
+      let query = db
+        .collection(`restaurants/${this.restaurantId()}/orders`)
+        .where("timePlaced", ">=", this.lastSeveralDays[this.dayIndex].date);
+      if (this.dayIndex > 0) {
+        query = query.where(
+          "timePlaced",
+          "<",
+          this.lastSeveralDays[this.dayIndex - 1].date
+        );
+      }
+      this.order_detacher = query.onSnapshot(result => {
+        let orders = result.docs.map(this.doc2data("order"));
+        orders = orders.sort((order0, order1) => {
+          if (order0.status === order1.status) {
+            return (order0.timeEstimated || order0.timePlaced) >
+              (order1.timeEstimated || order1.timePlaced)
+              ? -1
+              : 1;
+          }
+          return order0.status < order1.status ? -1 : 1;
+        });
+        this.orders = orders.map(order => {
+          order.timePlaced = order.timePlaced.toDate();
+          if (order.timeEstimated) {
+            order.timeEstimated = order.timeEstimated.toDate();
+          }
+          return order;
+        });
+      });
+    },
+    orderSelected(order) {
+      this.$router.push({
+        path:
+          "/admin/restaurants/" + this.restaurantId() + "/orders/" + order.id
+      });
+    },
+    getPickUpDaysInAdvance() {
+      return this.isNull(this.shopInfo.pickUpDaysInAdvance)
+        ? 3
+        : this.shopInfo.pickUpDaysInAdvance;
+    }
+  }
+};
+</script>

--- a/src/app/admin/OrderHistory.vue
+++ b/src/app/admin/OrderHistory.vue
@@ -12,7 +12,10 @@
             <!-- Back Button and Restaurant Profile -->
             <div class="level-left flex-1">
               <!-- Back Button -->
-              <back-button url="/admin/restaurants/" class="m-t-24 m-r-16" />
+              <back-button
+                :url="`/admin/restaurants/${restaurantId()}/orders`"
+                class="m-t-24 m-r-16"
+              />
 
               <!-- Restaurant Profile -->
               <div class="is-inline-flex flex-center m-t-24">
@@ -45,17 +48,7 @@
           <!-- Date and Sound -->
           <div class="level">
             <!-- Select Date -->
-            <div class="level-left">
-              <b-select v-model="dayIndex" class="m-t-24">
-                <option v-for="day in lastSeveralDays" :value="day.index" :key="day.index">
-                  {{ $d(day.date, "short") }} {{ orderCounter[moment(day.date).format("YYYY-MM-DD")] }}
-                  <span
-                    v-if="day.index === pickUpDaysInAdvance"
-                  >{{ $t("date.today") }}</span>
-                </option>
-              </b-select>
-            </div>
-
+            <div class="level-left"></div>
             <div class="level-right"></div>
           </div>
         </div>
@@ -107,19 +100,8 @@ export default {
   data() {
     return {
       shopInfo: {},
-      orders: [],
-      dayIndex: 0,
-      order_detacher: () => {}
+      orders: []
     };
-  },
-  watch: {
-    dayIndex() {
-      this.updateQueryDay();
-      this.dateWasUpdated();
-    },
-    "$route.query.day"() {
-      this.updateDayIndex();
-    }
   },
   async created() {
     this.checkAdminPermission();
@@ -131,71 +113,10 @@ export default {
       return;
     }
     this.shopInfo = restaurantDoc.data();
-    this.dayIndex = this.getPickUpDaysInAdvance();
 
-    if (this.$route.query.day) {
-      this.updateDayIndex();
-    }
-    this.dateWasUpdated();
-  },
-  destroyed() {
-    this.order_detacher();
-  },
-  computed: {
-    orderCounter() {
-      return this.lastSeveralDays.reduce((tmp, day) => {
-        const count = (
-          this.$store.state.orderObj[moment(day.date).format("YYYY-MM-DD")] ||
-          []
-        ).length;
-        if (count > 0) {
-          tmp[moment(day.date).format("YYYY-MM-DD")] = "(" + count + ")";
-        }
-        return tmp;
-      }, {});
-    },
-    pickUpDaysInAdvance() {
-      return this.getPickUpDaysInAdvance();
-    },
-    lastSeveralDays() {
-      return Array.from(Array(10 + this.pickUpDaysInAdvance).keys()).map(
-        index => {
-          const date = midNight(this.pickUpDaysInAdvance - index);
-          return { index, date };
-        }
-      );
-    }
-  },
-  methods: {
-    updateDayIndex() {
-      const dayIndex =
-        this.lastSeveralDays.findIndex(day => {
-          return (
-            moment(day.date).format("YYYY-MM-DD") === this.$route.query.day
-          );
-        }) || 0;
-      this.dayIndex = dayIndex > 0 ? dayIndex : 0;
-    },
-    updateQueryDay() {
-      const day = moment(this.lastSeveralDays[this.dayIndex].date).format(
-        "YYYY-MM-DD"
-      );
-      this.$router.push({
-        path: "/admin/restaurants/" + this.restaurantId() + "/orders?day=" + day
-      });
-    },
-    dateWasUpdated() {
-      this.order_detacher();
-      let query = db
-        .collection(`restaurants/${this.restaurantId()}/orders`)
-        .where("timePlaced", ">=", this.lastSeveralDays[this.dayIndex].date);
-      if (this.dayIndex > 0) {
-        query = query.where(
-          "timePlaced",
-          "<",
-          this.lastSeveralDays[this.dayIndex - 1].date
-        );
-      }
+    let query = db.collection(`restaurants/${this.restaurantId()}/orders`);
+    //  .where("timePlaced", ">=", this.lastSeveralDays[this.dayIndex].date);
+    /*
       this.order_detacher = query.onSnapshot(result => {
         let orders = result.docs.map(this.doc2data("order"));
         orders = orders.sort((order0, order1) => {
@@ -215,17 +136,15 @@ export default {
           return order;
         });
       });
-    },
+    */
+  },
+  computed: {},
+  methods: {
     orderSelected(order) {
       this.$router.push({
         path:
           "/admin/restaurants/" + this.restaurantId() + "/orders/" + order.id
       });
-    },
-    getPickUpDaysInAdvance() {
-      return this.isNull(this.shopInfo.pickUpDaysInAdvance)
-        ? 3
-        : this.shopInfo.pickUpDaysInAdvance;
     }
   }
 };

--- a/src/app/admin/OrderHistory.vue
+++ b/src/app/admin/OrderHistory.vue
@@ -114,29 +114,19 @@ export default {
     }
     this.shopInfo = restaurantDoc.data();
 
-    let query = db.collection(`restaurants/${this.restaurantId()}/orders`);
-    //  .where("timePlaced", ">=", this.lastSeveralDays[this.dayIndex].date);
-    /*
-      this.order_detacher = query.onSnapshot(result => {
-        let orders = result.docs.map(this.doc2data("order"));
-        orders = orders.sort((order0, order1) => {
-          if (order0.status === order1.status) {
-            return (order0.timeEstimated || order0.timePlaced) >
-              (order1.timeEstimated || order1.timePlaced)
-              ? -1
-              : 1;
-          }
-          return order0.status < order1.status ? -1 : 1;
-        });
-        this.orders = orders.map(order => {
-          order.timePlaced = order.timePlaced.toDate();
-          if (order.timeEstimated) {
-            order.timeEstimated = order.timeEstimated.toDate();
-          }
-          return order;
-        });
-      });
-    */
+    let query = db
+      .collection(`restaurants/${this.restaurantId()}/orders`)
+      .orderBy("timePlaced", "desc");
+    let snapshot = await query.get();
+    let orders = snapshot.docs.map(this.doc2data("order"));
+    console.log(orders);
+    this.orders = orders.map(order => {
+      order.timePlaced = order.timePlaced.toDate();
+      if (order.timeEstimated) {
+        order.timeEstimated = order.timeEstimated.toDate();
+      }
+      return order;
+    });
   },
   computed: {},
   methods: {

--- a/src/app/admin/OrderListPage.vue
+++ b/src/app/admin/OrderListPage.vue
@@ -80,6 +80,11 @@
               :order="order"
             />
           </div>
+          <div class="m-t-24">
+            <nuxt-link
+              :to="`/admin/restaurants/${this.restaurantId()}/history`"
+            >{{$t("admin.order.history")}}</nuxt-link>
+          </div>
         </div>
       </div>
       <!-- Right Gap -->

--- a/src/routes.js
+++ b/src/routes.js
@@ -89,6 +89,10 @@ export const customRoutes = [
         component: "admin/OrderListPage.vue"
       },
       {
+        path: "history",
+        component: "admin/OrderHistory.vue"
+      },
+      {
         name: "admin-suspend",
         path: "suspend",
         component: "admin/OrderSuspendPage.vue"


### PR DESCRIPTION
レストラン側が、オーダーの全履歴を見ることが出来るようにしました。
- このページへのリンクは、オーダー一覧（ダッシュボード）の一番下に置きました
- 30個ずつページングしています
- snapshot ではなく、get で取得しています
- isSuperView を使って日付も表示しています
- 戻るボタンで、オーダー一覧に戻ります