### PR TITLE
Categories5

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -337,6 +337,7 @@
     "category1": "Category 1",
     "category2": "Category 2",
     "count": "Count",
+    "unspecified": "(unspecified)",
     "status": {
       "unexpected": "Unexpected",
       "error": "Error",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -337,6 +337,7 @@
     "category1": "Catégorie 1",
     "category2": "Catégorie 2",
     "count": "Compter",
+    "unspecified": "(non spécifié)",
     "status": {
       "unexpected": "Inattendue",
       "error": "Erreur",

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -337,6 +337,7 @@
     "category1": "カテゴリ１",
     "category2": "カテゴリ２",
     "count": "受注数",
+    "unspecified": "(未記入)",
     "status": {
       "unexpected": "(Unexpected)",
       "error": "エラー",

--- a/src/app/admin/Order/ReportDetails.vue
+++ b/src/app/admin/Order/ReportDetails.vue
@@ -92,7 +92,7 @@ export default {
               order.timeConfirmed &&
               moment(order.timeConfirmed).format("YYYY/MM/DD HH:MM"),
             phoneNumber: formatNational(parsePhoneNumber(order.phoneNumber)),
-            userName: order.name,
+            userName: order.name || this.$t("order.unspecified"),
             count: order.order[id],
             itemName: menuItem.itemName,
             statusName: this.$t(`order.status.${status}`),
@@ -101,24 +101,8 @@ export default {
           });
         });
       });
-      console.log(items);
+      //console.log(items);
       return items;
-      /*
-      return this.orders.map(order => {
-        return {
-          date: moment(order.timeConfirmed).format("YYYY/MM/DD"),
-          foodRevenue: order.accounting.food.revenue,
-          foodTax: order.accounting.food.tax,
-          alcoholRevenue: order.accounting.alcohol.revenue,
-          salesTax: order.accounting.alcohol.tax,
-          tipShort: order.accounting.service.revenue,
-          serviceTax: order.accounting.service.tax,
-          total: order.totalCharge,
-          name: nameOfOrder(order),
-          payment: order.payment?.stripe ? "stripe" : ""
-        };
-      });
-        */
     }
   }
 };

--- a/src/app/admin/Order/ReportDetails.vue
+++ b/src/app/admin/Order/ReportDetails.vue
@@ -73,6 +73,7 @@ export default {
         "statusName",
         "userName",
         "phoneNumber",
+        "timeRequested",
         "dateConfirmed",
         "itemName",
         "category1",
@@ -102,6 +103,9 @@ export default {
           items.push({
             id: `${order.id}/${id}`,
             name: nameOfOrder(order),
+            timeRequested:
+              order.timePlaced &&
+              moment(order.timePlaced).format("YYYY/MM/DD HH:MM"),
             dateConfirmed:
               order.timeConfirmed &&
               moment(order.timeConfirmed).format("YYYY/MM/DD HH:MM"),

--- a/src/app/admin/Order/ReportDetails.vue
+++ b/src/app/admin/Order/ReportDetails.vue
@@ -105,10 +105,10 @@ export default {
             name: nameOfOrder(order),
             timeRequested:
               order.timePlaced &&
-              moment(order.timePlaced).format("YYYY/MM/DD HH:MM"),
+              moment(order.timePlaced).format("YYYY/MM/DD HH:mm"),
             dateConfirmed:
               order.timeConfirmed &&
-              moment(order.timeConfirmed).format("YYYY/MM/DD HH:MM"),
+              moment(order.timeConfirmed).format("YYYY/MM/DD HH:mm"),
             phoneNumber: formatNational(parsePhoneNumber(order.phoneNumber)),
             userName: order.name || this.$t("order.unspecified"),
             count: order.order[id],

--- a/src/app/admin/Order/ReportDetails.vue
+++ b/src/app/admin/Order/ReportDetails.vue
@@ -14,7 +14,13 @@
         </tr>
       </table>
     </div>
-    <download-csv :data="tableData" :fields="fields" :fieldNames="fieldNames" :fileName="fileName">
+    <download-csv
+      :data="tableData"
+      :fields="fields"
+      :fieldNames="fieldNames"
+      :fileName="fileName"
+      :formulas="formulas"
+    >
       <b-button class="m-t-16 b-reset h-36 r-36 bg-form">
         <span class="p-l-16 p-r-16">
           <i class="material-icons c-primary s-18 m-r-8">save_alt</i>
@@ -55,6 +61,12 @@ export default {
     //console.log("***", this.orders);
   },
   computed: {
+    formulas() {
+      return {
+        count: "sum",
+        total: "sum"
+      };
+    },
     fields() {
       return [
         "name",

--- a/src/app/admin/Order/ReportDetails.vue
+++ b/src/app/admin/Order/ReportDetails.vue
@@ -65,7 +65,9 @@ export default {
         "itemName",
         "category1",
         "category2",
-        "count"
+        "count",
+        "total",
+        "payment"
       ];
     },
     fieldNames() {
@@ -83,7 +85,7 @@ export default {
           }
           return result;
         }, "unexpected");
-        ids.forEach(id => {
+        ids.forEach((id, index) => {
           const menuItem = order.menuItems[id];
           items.push({
             id: `${order.id}/${id}`,
@@ -97,7 +99,9 @@ export default {
             itemName: menuItem.itemName,
             statusName: this.$t(`order.status.${status}`),
             category1: menuItem.category1 || "",
-            category2: menuItem.category2 || ""
+            category2: menuItem.category2 || "",
+            total: index === 0 ? order.totalCharge : "",
+            payment: order.payment?.stripe ? "stripe" : ""
           });
         });
       });

--- a/src/app/admin/ReportPage.vue
+++ b/src/app/admin/ReportPage.vue
@@ -290,6 +290,7 @@ export default {
         const multiple = this.$store.getters.stripeRegion.multiple;
         this.orders = orders.map(order => {
           order.timeConfirmed = order.timeConfirmed.toDate();
+          order.timePlaced = order.timePlaced.toDate();
           if (!order.accounting) {
             order.accounting = {
               food: {

--- a/src/components/DownloadCSV.vue
+++ b/src/components/DownloadCSV.vue
@@ -44,6 +44,9 @@ export default {
       let footers = "";
       if (this.formulas) {
         const formulas = this.fields.map((field, index) => {
+          if (index === 0) {
+            return this.$t("order.total");
+          }
           const formula = this.formulas[field];
           const col = String.fromCharCode(0x41 + index); // Handles only A-Z
           return formula

--- a/src/components/DownloadCSV.vue
+++ b/src/components/DownloadCSV.vue
@@ -45,7 +45,10 @@ export default {
       if (this.formulas) {
         const formulas = this.fields.map(field => {
           const formula = this.formulas[field];
-          return formula ? `=${formula}(I1:I5)` : "";
+          const col = "I";
+          return formula
+            ? `=${formula}(${col}2:${col}${this.data.length + 1})`
+            : "";
         });
         footers = `\n${formulas.join(",")}`;
       }

--- a/src/components/DownloadCSV.vue
+++ b/src/components/DownloadCSV.vue
@@ -43,9 +43,9 @@ export default {
         .join("\n");
       let footers = "";
       if (this.formulas) {
-        const formulas = this.fields.map(field => {
+        const formulas = this.fields.map((field, index) => {
           const formula = this.formulas[field];
-          const col = "I";
+          const col = String.fromCharCode(0x41 + index); // Handles only A-Z
           return formula
             ? `=${formula}(${col}2:${col}${this.data.length + 1})`
             : "";

--- a/src/components/DownloadCSV.vue
+++ b/src/components/DownloadCSV.vue
@@ -24,6 +24,11 @@ export default {
     fieldNames: {
       type: Array,
       required: false
+    },
+    formulas: {
+      type: Object,
+      required: false,
+      default: null
     }
   },
   computed: {
@@ -36,7 +41,15 @@ export default {
             .join(",");
         })
         .join("\n");
-      return `\ufeff${header}\n${rows}`;
+      let footers = "";
+      if (this.formulas) {
+        const formulas = this.fields.map(field => {
+          const formula = this.formulas[field];
+          return formula ? `=${formula}(I1:I5)` : "";
+        });
+        footers = `\n${formulas.join(",")}`;
+      }
+      return `\ufeff${header}\n${rows}${footers}`;
     }
   },
   methods: {

--- a/src/components/DownloadOrders.vue
+++ b/src/components/DownloadOrders.vue
@@ -62,13 +62,13 @@ export default {
           return result;
         }, "unexpected");
         return {
-          datePlaced: moment(order.timePlaced).format("YYYY/MM/DD HH:MM"),
+          datePlaced: moment(order.timePlaced).format("YYYY/MM/DD HH:mm"),
           dateEstimated:
             order.timeEstimated &&
-            moment(order.timeEstimated).format("YYYY/MM/DD HH:MM"),
+            moment(order.timeEstimated).format("YYYY/MM/DD HH:mm"),
           dateConfirmed:
             order.timeConfirmed &&
-            moment(order.timeConfirmed).format("YYYY/MM/DD HH:MM"),
+            moment(order.timeConfirmed).format("YYYY/MM/DD HH:mm"),
           statusName: this.$t(`order.status.${status}`),
           totalCount: totalCount,
           total: order.totalCharge,


### PR DESCRIPTION
伊藤忠さんからのリクエストの、

【修正①】注文者の記入がない場合は「空欄」ではなく「未記入」と記載（店舗側で「記入漏れ」と勘違いを生まないようにする為）
【修正③】「受注金額」欄、「支払方法」欄「合計金額」を追加（複数のシートを行き来せずに済むようにする為）

を実装したものです（ただし、「合計金額」は実装していません。理由は下に書きます）。

【修正④】受け渡し時刻につき、全ての行（同一注文番号が複数行にわたる場合も）に記載

は既に実装済みですが、これが記載されるのはステータスが受け渡し完了のもののみです。

【修正②】受注数に「合計受注数」を追加（検品時に確認しやすいようにする為）

は計算して無理やり追加することは可能ですが、Excel 上では計算式にはならないので、CVSファイルとして適切なのか、少し疑問です。修正③の「合計金額」も同じ理由で実装していません。









