### PR TITLE
Qrcode on orderpage

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -338,6 +338,7 @@
     "category2": "Category 2",
     "count": "Count",
     "unspecified": "(unspecified)",
+    "adminQRCode": "Confirmation QR Code",
     "status": {
       "unexpected": "Unexpected",
       "error": "Error",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -338,6 +338,7 @@
     "category2": "Catégorie 2",
     "count": "Compter",
     "unspecified": "(non spécifié)",
+    "adminQRCode": "Confirmation QR Code",
     "status": {
       "unexpected": "Inattendue",
       "error": "Erreur",

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -338,6 +338,7 @@
     "category2": "カテゴリ２",
     "count": "受注数",
     "unspecified": "(未記入)",
+    "adminQRCode": "確認用QRCode",
     "status": {
       "unexpected": "(Unexpected)",
       "error": "エラー",

--- a/src/app/user/OrderPage.vue
+++ b/src/app/user/OrderPage.vue
@@ -352,7 +352,9 @@ export default {
   },
   computed: {
     urlAdminOrderPage() {
-      return "https://www.amazon.com";
+      return `${
+        location.origin
+      }/admin/restaurants/${this.restaurantId()}/orders/${this.orderId}`;
     },
     showAddLine() {
       return (

--- a/src/app/user/OrderPage.vue
+++ b/src/app/user/OrderPage.vue
@@ -276,6 +276,10 @@
               </div>-->
             </div>
           </div>
+          <!-- QR Code -->
+          <div class="align-center">
+            <qrcode :value="'https://www.google.com'" :options="{ width: 160 }"></qrcode>
+          </div>
         </div>
         <!-- Right Gap -->
         <div class="column is-narrow w-24"></div>

--- a/src/app/user/OrderPage.vue
+++ b/src/app/user/OrderPage.vue
@@ -277,8 +277,8 @@
             </div>
           </div>
           <!-- QR Code -->
-          <div class="align-center">
-            <qrcode :value="'https://www.google.com'" :options="{ width: 160 }"></qrcode>
+          <div class="m-t-24 align-center">
+            <qrcode :value="urlAdminOrderPage" :options="{ width: 160 }"></qrcode>
           </div>
         </div>
         <!-- Right Gap -->
@@ -351,6 +351,9 @@ export default {
     }
   },
   computed: {
+    urlAdminOrderPage() {
+      return "https://www.amazon.com";
+    },
     showAddLine() {
       return (
         this.isLineEnabled &&

--- a/src/app/user/OrderPage.vue
+++ b/src/app/user/OrderPage.vue
@@ -274,11 +274,11 @@
                   </span>
                 </b-button>
               </div>-->
+              <!-- QR Code -->
+              <div class="m-t-24 align-center">
+                <qrcode :value="urlAdminOrderPage" :options="{ width: 160 }"></qrcode>
+              </div>
             </div>
-          </div>
-          <!-- QR Code -->
-          <div class="m-t-24 align-center">
-            <qrcode :value="urlAdminOrderPage" :options="{ width: 160 }"></qrcode>
           </div>
         </div>
         <!-- Right Gap -->

--- a/src/app/user/OrderPage.vue
+++ b/src/app/user/OrderPage.vue
@@ -275,8 +275,11 @@
                 </b-button>
               </div>-->
               <!-- QR Code -->
-              <div class="m-t-24 align-center">
-                <qrcode :value="urlAdminOrderPage" :options="{ width: 160 }"></qrcode>
+              <div class="m-t-24">
+                <div class="t-h6 c-text-black-disabled">{{ $t('order.adminQRCode') }}</div>
+                <div class="m-t-8 align-center">
+                  <qrcode :value="urlAdminOrderPage" :options="{ width: 160 }"></qrcode>
+                </div>
               </div>
             </div>
           </div>


### PR DESCRIPTION
ユーザー向けの注文ステータスページの最後に、お店向けの注文ステータスページへのQRCodeを貼り付けました。本人・注文確認に店舗で使えるし、将来は受け渡しロッカーに使ってもらうことも可能です。