### PR TITLE
New order flow

### DIFF
--- a/functions/src/stripe/intent.ts
+++ b/functions/src/stripe/intent.ts
@@ -144,7 +144,8 @@ export const confirm = async (db: FirebaseFirestore.Firestore, data: any, contex
         throw new functions.https.HttpsError('invalid-argument', `The order does not exist. ${orderRef.path}`)
       }
       // Check the stock status.
-      if (order.status !== order_status.cooking_completed) {
+      if (order.status !== order_status.cooking_completed // backward compability (99.99% unnecessary)
+        && order.status !== order_status.order_accepted) {
         throw new functions.https.HttpsError('failed-precondition', 'This order is not ready yet.')
       }
 

--- a/functions/src/stripe/intent.ts
+++ b/functions/src/stripe/intent.ts
@@ -113,8 +113,8 @@ export const confirm = async (db: FirebaseFirestore.Firestore, data: any, contex
   const uid = utils.validate_auth(context);
   const stripe = utils.get_stripe();
 
-  const { restaurantId, orderId } = data
-  utils.validate_params({ restaurantId, orderId })
+  const { restaurantId, orderId, lng } = data
+  utils.validate_params({ restaurantId, orderId }) // lng is optional
 
   const orderRef = db.doc(`restaurants/${restaurantId}/orders/${orderId}`)
   const stripeRef = db.doc(`restaurants/${restaurantId}/orders/${orderId}/system/stripe`)
@@ -134,11 +134,13 @@ export const confirm = async (db: FirebaseFirestore.Firestore, data: any, contex
     throw new functions.https.HttpsError('permission-denied', 'You do not have permission to confirm this request.')
   }
 
+  let order: Order | undefined = undefined;
+
   try {
-    return await db.runTransaction(async transaction => {
+    let result = await db.runTransaction(async transaction => {
 
       const snapshot = await transaction.get(orderRef)
-      const order = Order.fromSnapshot<Order>(snapshot)
+      order = Order.fromSnapshot<Order>(snapshot)
 
       if (!snapshot.exists) {
         throw new functions.https.HttpsError('invalid-argument', `The order does not exist. ${orderRef.path}`)
@@ -174,6 +176,14 @@ export const confirm = async (db: FirebaseFirestore.Firestore, data: any, contex
 
       return { success: true }
     })
+
+    if (order!.sendSMS) {
+      let msgKey = "msg_cooking_completed"
+      const orderName = nameOfOrder(order!.number)
+      await sendMessage(db, lng, msgKey, restaurantData.restaurantName, orderName, order!.uid, order!.phoneNumber, restaurantId, orderId, {})
+    }
+
+    return result
   } catch (error) {
     throw utils.process_error(error)
   }

--- a/lang/en.json
+++ b/lang/en.json
@@ -347,8 +347,8 @@
       "validation_ok": "Validated",
       "order_placed": "Order Placed",
       "order_accepted": "Accepted",
-      "cooking_completed": "Ready To Pickup",
-      "customer_picked_up": "Complete",
+      "cooking_completed": "Cooking Complete",
+      "customer_picked_up": "Ready to Pickup",
       "order_canceled": "Canceled",
       "order_refunded": "Refunded"
     }

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -348,7 +348,7 @@
       "order_placed": "注文済み",
       "order_accepted": "受付済み",
       "cooking_completed": "調理済み",
-      "customer_picked_up": "受け渡し完了",
+      "customer_picked_up": "受け渡し準備完了",
       "order_canceled": "キャンセル済み",
       "order_refunded": "払い戻し済み"
     }

--- a/src/app/admin/OrderInfoPage.vue
+++ b/src/app/admin/OrderInfoPage.vue
@@ -257,7 +257,7 @@ export default {
 
   data() {
     return {
-      orderStates: ["order_placed", "order_accepted", "cooking_completed"],
+      orderStates: ["order_placed", "order_accepted"], // no longer "cooking_completed"
       updating: "",
       shopInfo: {},
       menuObj: {},

--- a/src/app/admin/OrderInfoPage.vue
+++ b/src/app/admin/OrderInfoPage.vue
@@ -448,20 +448,23 @@ export default {
         case order_status.order_placed:
           return {
             order_accepted: true,
-            cooking_completed: true,
+            //cooking_completed: true,
             order_canceled: true
           };
         case order_status.order_accepted:
           return {
             cooking_completed: true,
-            order_canceled: true
+            order_canceled: true,
+            customer_picked_up: true // both paid and unpaid
           };
+        /*
         case order_status.cooking_completed:
           return {
             order_accepted: true,
             order_canceled: true,
             customer_picked_up: true // both paid and unpaid
           };
+        */
         case order_status.customer_picked_up:
           return {
             order_refunded: true


### PR DESCRIPTION
注文処理のフローを
　注文済み→受付済み→受け渡し準備完了（ここで課金）
と変更したものです。

変更点は：
1. 状態遷移の変更（クライアントとサーバー）し、order_accepted から直接 customer_picked_up に遷移できるように変更
2. customer_picked_up の表示を「受け渡し準備完了」に変更
3. customer_picked_up に遷移した時に、ユーザーにメッセージを送るように変更

まずはこれで一旦 merge した後に、

4. customer_picked_up を ready_to_pickup に変更
5. orderUpdate 中の 余計なコードの削除
6. 新しい定義の customer_picked_up の追加

の変更をしたいと思います。