### PR TITLE
order state transition

### DIFF
--- a/functions/src/functions/order.ts
+++ b/functions/src/functions/order.ts
@@ -113,7 +113,7 @@ export const update = async (db: FirebaseFirestore.Firestore, data: any, context
           case order_status.cooking_completed:
             msgKey = "msg_cooking_completed"
             return true
-          case order_status.customer_picked_up:
+          case order_status.ready_to_pickup:
             return !(order.payment && order.payment.stripe) // only "unpaid" order can be manually completed
         }
         return false
@@ -141,7 +141,7 @@ export const update = async (db: FirebaseFirestore.Firestore, data: any, context
       if (status === order_status.cooking_completed) {
         props.orderCookingCompletedAt = admin.firestore.Timestamp.now();
       }
-      if (status === order_status.customer_picked_up) {
+      if (status === order_status.ready_to_pickup) {
         // Make it compatible with striped orders.
         props.orderCustomerPickedUpAt = admin.firestore.Timestamp.now();
         props.timeConfirmed = props.updatedAt;

--- a/functions/src/models/Order.ts
+++ b/functions/src/models/Order.ts
@@ -12,7 +12,7 @@ export type Status =
   300 | // order_placed
   400 | // order_accepted
   500 | // cooking_completed
-  600   // customer_picked_up
+  600   // ready_to_pickup
 
 class Payment {
   stripe!: boolean

--- a/functions/src/stripe/intent.ts
+++ b/functions/src/stripe/intent.ts
@@ -164,7 +164,7 @@ export const confirm = async (db: FirebaseFirestore.Firestore, data: any, contex
       })
       transaction.set(orderRef, {
         timeConfirmed: admin.firestore.FieldValue.serverTimestamp(),
-        status: order_status.customer_picked_up,
+        status: order_status.ready_to_pickup,
         updatedAt: admin.firestore.Timestamp.now(),
         payment: {
           stripe: "confirmed"
@@ -227,7 +227,7 @@ export const cancel = async (db: FirebaseFirestore.Firestore, data: any, context
         }
       } else if (uid === venderId) {
         // Admin can cancel it before confirmed
-        if (order.status >= order_status.customer_picked_up) {
+        if (order.status >= order_status.ready_to_pickup) {
           throw new functions.https.HttpsError('permission-denied', 'Invalid order state to cancel.')
         }
         sendSMS = order.sendSMS

--- a/lang/en.json
+++ b/lang/en.json
@@ -349,6 +349,7 @@
       "order_accepted": "Accepted",
       "cooking_completed": "Cooking Complete",
       "ready_to_pickup": "Ready to Pickup",
+      "transaction_complete": "Pickup Complete",
       "order_canceled": "Canceled",
       "order_refunded": "Refunded"
     }

--- a/lang/en.json
+++ b/lang/en.json
@@ -348,7 +348,7 @@
       "order_placed": "Order Placed",
       "order_accepted": "Accepted",
       "cooking_completed": "Cooking Complete",
-      "customer_picked_up": "Ready to Pickup",
+      "ready_to_pickup": "Ready to Pickup",
       "order_canceled": "Canceled",
       "order_refunded": "Refunded"
     }

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -348,7 +348,7 @@
       "order_placed": "Commande éffectuer",
       "order_accepted": "Accepter",
       "cooking_completed": "Prêt à ramasser",
-      "customer_picked_up": "Complete",
+      "ready_to_pickup": "Complete",
       "order_canceled": "Annulé",
       "order_refunded": "Remboursé"
     }

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -349,6 +349,7 @@
       "order_accepted": "受付済み",
       "cooking_completed": "調理済み",
       "ready_to_pickup": "受け渡し準備完了",
+      "transaction_complete": "受け渡し完了",
       "order_canceled": "キャンセル済み",
       "order_refunded": "払い戻し済み"
     }

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -348,7 +348,7 @@
       "order_placed": "注文済み",
       "order_accepted": "受付済み",
       "cooking_completed": "調理済み",
-      "customer_picked_up": "受け渡し準備完了",
+      "ready_to_pickup": "受け渡し準備完了",
       "order_canceled": "キャンセル済み",
       "order_refunded": "払い戻し済み"
     }

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -329,7 +329,7 @@
     "orderNotice": "注文時のご注意",
     "datePlaced": "注文時刻",
     "dateEstimated": "完了予定時刻",
-    "dateConfirmed": "受け渡し時刻",
+    "dateConfirmed": "準備完了時刻",
     "statusName": "ステータス",
     "phoneNumber": "お客様の電話番号",
     "totalCount": "注文総数",

--- a/src/app/admin/Index.vue
+++ b/src/app/admin/Index.vue
@@ -198,7 +198,7 @@
       <div class="column">
         <div class="m-l-24 m-r-24">
           <!-- Payment -->
-          <payment-section @updateUnsetWarning="updateUnsetWarning($event)"/>
+          <payment-section @updateUnsetWarning="updateUnsetWarning($event)" />
 
           <!-- Notes -->
           <div class="m-t-24">
@@ -302,7 +302,7 @@ export default {
                 db
                   .collection(`restaurants/${restaurant.id}/orders`)
                   .where("timePlaced", ">=", midNight())
-                  // IDEALLY: .where("status", "<", order_status.customer_picked_up)
+                  // IDEALLY: .where("status", "<", order_status.ready_to_pickup)
                   .onSnapshot(result => {
                     this.restaurantItems = this.restaurantItems.map(
                       (r2, i2) => {
@@ -311,9 +311,7 @@ export default {
                             .map(doc => doc.data())
                             .filter(data => {
                               // We need this filter here because Firebase does not allow us to do
-                              return (
-                                data.status < order_status.customer_picked_up
-                              );
+                              return data.status < order_status.ready_to_pickup;
                             }).length;
                         }
                         return r2;

--- a/src/app/admin/OrderInfoPage.vue
+++ b/src/app/admin/OrderInfoPage.vue
@@ -358,6 +358,9 @@ export default {
         ),
         order_canceled_by_customer: this.timeStampToText(
           this.orderInfo.orderCustomerCanceledAt
+        ),
+        transaction_complete: this.timeStampToText(
+          this.orderInfo.transactionCompletedAt
         )
       };
       console.log(this.orderInfo);
@@ -510,6 +513,7 @@ export default {
       const timezone = moment.tz.guess();
       const newStatus = order_status[statusKey];
       if (newStatus === this.orderInfo.status) {
+        console.log("same status - no need to process");
         return;
       }
       const orderUpdate = functions.httpsCallable("orderUpdate");

--- a/src/app/admin/OrderInfoPage.vue
+++ b/src/app/admin/OrderInfoPage.vue
@@ -321,6 +321,9 @@ export default {
     });
   },
   computed: {
+    possibleTransitions() {
+      return possible_transitions[this.orderInfo.status] || {};
+    },
     cancelStatus() {
       if (this.orderInfo.status === order_status.order_canceled) {
         if (this.orderInfo.orderCustomerCanceledAt) {
@@ -458,13 +461,10 @@ export default {
     displayOption(option) {
       return formatOption(option, price => this.$n(price, "currency"));
     },
-    possibleTransition() {
-      return possible_transitions[this.orderInfo.status] || {};
-    },
     isValidTransition(newStatus) {
       const newStatusValue = order_status[newStatus];
       return (
-        this.possibleTransition()[newStatusValue] ||
+        this.possibleTransitions[newStatusValue] ||
         (newStatusValue === this.orderInfo.status &&
           newStatus !== "order_canceled")
       );

--- a/src/app/admin/OrderInfoPage.vue
+++ b/src/app/admin/OrderInfoPage.vue
@@ -243,7 +243,7 @@
 import { db, functions, firestore } from "~/plugins/firebase.js";
 import BackButton from "~/components/BackButton";
 import OrderedItem from "~/app/admin/Order/OrderedItem";
-import { order_status } from "~/plugins/constant.js";
+import { order_status, possible_transitions } from "~/plugins/constant.js";
 import { nameOfOrder } from "~/plugins/strings.js";
 import {
   parsePhoneNumber,
@@ -456,34 +456,7 @@ export default {
       return formatOption(option, price => this.$n(price, "currency"));
     },
     possibleTransition() {
-      switch (this.orderInfo.status) {
-        case order_status.order_placed:
-          return {
-            order_accepted: true,
-            //cooking_completed: true,
-            order_canceled: true
-          };
-        case order_status.order_accepted:
-          return {
-            cooking_completed: true,
-            order_canceled: true,
-            ready_to_pickup: true // both paid and unpaid
-          };
-        /*
-        case order_status.cooking_completed:
-          return {
-            order_accepted: true,
-            order_canceled: true,
-            ready_to_pickup: true // both paid and unpaid
-          };
-        */
-        case order_status.ready_to_pickup:
-          return {
-            order_refunded: true,
-            transaction_complete: true
-          };
-      }
-      return {};
+      return possible_transitions[this.orderInfo.status] || {};
     },
     isValidTransition(newStatus) {
       return (

--- a/src/app/admin/OrderInfoPage.vue
+++ b/src/app/admin/OrderInfoPage.vue
@@ -199,6 +199,20 @@
                     <div class="t-caption c-text-black-medium">{{timeOfEvents['ready_to_pickup']}}</div>
                   </b-button>
                 </div>
+                <div class="align-center m-t-24">
+                  <b-button
+                    class="op-button-medium w-256"
+                    :class="classOf('transaction_complete')"
+                    :loading="updating==='transaction_complete'"
+                    :disabled="!isValidTransition('transaction_complete')"
+                    @click="handleChangeStatus('transaction_complete')"
+                  >
+                    <div>{{ $t("order.status.transaction_complete") }}</div>
+                    <div
+                      class="t-caption c-text-black-medium"
+                    >{{timeOfEvents['transaction_complete']}}</div>
+                  </b-button>
+                </div>
               </div>
             </div>
           </div>
@@ -465,7 +479,8 @@ export default {
         */
         case order_status.ready_to_pickup:
           return {
-            order_refunded: true
+            order_refunded: true,
+            transaction_complete: true
           };
       }
       return {};

--- a/src/app/admin/OrderInfoPage.vue
+++ b/src/app/admin/OrderInfoPage.vue
@@ -462,9 +462,10 @@ export default {
       return possible_transitions[this.orderInfo.status] || {};
     },
     isValidTransition(newStatus) {
+      const newStatusValue = order_status[newStatus];
       return (
-        this.possibleTransition()[newStatus] ||
-        (order_status[newStatus] === this.orderInfo.status &&
+        this.possibleTransition()[newStatusValue] ||
+        (newStatusValue === this.orderInfo.status &&
           newStatus !== "order_canceled")
       );
     },

--- a/src/app/admin/OrderInfoPage.vue
+++ b/src/app/admin/OrderInfoPage.vue
@@ -190,15 +190,13 @@
                 <div class="align-center m-t-24">
                   <b-button
                     class="op-button-medium w-256"
-                    :class="classOf('customer_picked_up')"
-                    :loading="updating==='customer_picked_up'"
-                    :disabled="!isValidTransition('customer_picked_up')"
+                    :class="classOf('ready_to_pickup')"
+                    :loading="updating==='ready_to_pickup'"
+                    :disabled="!isValidTransition('ready_to_pickup')"
                     @click="handleComplete()"
                   >
-                    <div>{{ $t("order.status." + 'customer_picked_up') }}</div>
-                    <div
-                      class="t-caption c-text-black-medium"
-                    >{{timeOfEvents['customer_picked_up']}}</div>
+                    <div>{{ $t("order.status." + 'ready_to_pickup') }}</div>
+                    <div class="t-caption c-text-black-medium">{{timeOfEvents['ready_to_pickup']}}</div>
                   </b-button>
                 </div>
               </div>
@@ -340,7 +338,7 @@ export default {
         cooking_completed: this.timeStampToText(
           this.orderInfo.orderCookingCompletedAt
         ),
-        customer_picked_up: this.timeStampToText(this.orderInfo.timeConfirmed),
+        ready_to_pickup: this.timeStampToText(this.orderInfo.timeConfirmed),
         order_canceled_by_restaurant: this.timeStampToText(
           this.orderInfo.orderRestaurantCanceledAt
         ),
@@ -455,17 +453,17 @@ export default {
           return {
             cooking_completed: true,
             order_canceled: true,
-            customer_picked_up: true // both paid and unpaid
+            ready_to_pickup: true // both paid and unpaid
           };
         /*
         case order_status.cooking_completed:
           return {
             order_accepted: true,
             order_canceled: true,
-            customer_picked_up: true // both paid and unpaid
+            ready_to_pickup: true // both paid and unpaid
           };
         */
-        case order_status.customer_picked_up:
+        case order_status.ready_to_pickup:
           return {
             order_refunded: true
           };
@@ -493,14 +491,14 @@ export default {
       return "";
     },
     async handleComplete() {
-      if (this.orderInfo.status === order_status.customer_picked_up) {
+      if (this.orderInfo.status === order_status.ready_to_pickup) {
         return; // no need to call the server
       }
       if (this.hasStripe) {
         const orderId = this.$route.params.orderId;
         //console.log("handleComplete with Stripe", orderId);
         try {
-          this.updating = "customer_picked_up";
+          this.updating = "ready_to_pickup";
           const { data } = await stripeConfirmIntent({
             restaurantId: this.restaurantId() + this.forcedError("confirm"),
             orderId
@@ -517,7 +515,7 @@ export default {
           this.updating = "";
         }
       } else {
-        this.handleChangeStatus("customer_picked_up");
+        this.handleChangeStatus("ready_to_pickup");
       }
     },
     async handleChangeStatus(statusKey) {

--- a/src/assets/scss/orders.scss
+++ b/src/assets/scss/orders.scss
@@ -26,8 +26,8 @@
   border: 0;
 }
 
-.customer_picked_up,
-.customer_picked_up:hover {
+.ready_to_pickup,
+.ready_to_pickup:hover {
   @extend .c-status-purple;
   @extend .bg-status-purple-bg;
   border: 0;

--- a/src/plugins/constant.js
+++ b/src/plugins/constant.js
@@ -14,16 +14,21 @@ export const order_status = {
 export const possible_transitions = {
   [order_status.order_placed]: {
     order_accepted: true,
-    order_canceled: true
+    order_canceled: true,
+    [order_status.order_accepted]: true,
+    [order_status.order_canceled]: true
   },
   [order_status.order_accepted]: {
-    cooking_completed: true,
     order_canceled: true,
-    ready_to_pickup: true // both paid and unpaid
+    ready_to_pickup: true, // both paid and unpaid
+    [order_status.order_canceled]: true,
+    [order_status.ready_to_pickup]: true // both paid and unpaid
   },
   [order_status.ready_to_pickup]: {
     order_refunded: true,
-    transaction_complete: true
+    transaction_complete: true,
+    [order_status.order_refunded]: true,
+    [order_status.transaction_complete]: true
   }
 };
 

--- a/src/plugins/constant.js
+++ b/src/plugins/constant.js
@@ -13,20 +13,14 @@ export const order_status = {
 
 export const possible_transitions = {
   [order_status.order_placed]: {
-    order_accepted: true,
-    order_canceled: true,
     [order_status.order_accepted]: true,
     [order_status.order_canceled]: true
   },
   [order_status.order_accepted]: {
-    order_canceled: true,
-    ready_to_pickup: true, // both paid and unpaid
     [order_status.order_canceled]: true,
     [order_status.ready_to_pickup]: true // both paid and unpaid
   },
   [order_status.ready_to_pickup]: {
-    order_refunded: true,
-    transaction_complete: true,
     [order_status.order_refunded]: true,
     [order_status.transaction_complete]: true
   }

--- a/src/plugins/constant.js
+++ b/src/plugins/constant.js
@@ -4,8 +4,9 @@ export const order_status = {
   validation_ok: 200, // by functions
   order_placed: 300, // by user and stripe
   order_accepted: 400, // by restaurant
-  cooking_completed: 500, // by restaurant
+  cooking_completed: 500, // by restaurant (obsolete)
   ready_to_pickup: 600, // by restaurant and stripe
+  transaction_complete: 650, // by restaurant (optional)
   order_canceled: 700, // by restaurant or user
   order_refunded: 800 // by restaurant
 };

--- a/src/plugins/constant.js
+++ b/src/plugins/constant.js
@@ -11,6 +11,22 @@ export const order_status = {
   order_refunded: 800 // by restaurant
 };
 
+export const possible_transitions = {
+  [order_status.order_placed]: {
+    order_accepted: true,
+    order_canceled: true
+  },
+  [order_status.order_accepted]: {
+    cooking_completed: true,
+    order_canceled: true,
+    ready_to_pickup: true // both paid and unpaid
+  },
+  [order_status.ready_to_pickup]: {
+    order_refunded: true,
+    transaction_complete: true
+  }
+};
+
 export const order_error = {
   validation_error: 100,
   order_canceled_by_customer: 200,

--- a/src/plugins/constant.js
+++ b/src/plugins/constant.js
@@ -5,7 +5,7 @@ export const order_status = {
   order_placed: 300, // by user and stripe
   order_accepted: 400, // by restaurant
   cooking_completed: 500, // by restaurant
-  customer_picked_up: 600, // by restaurant and stripe
+  ready_to_pickup: 600, // by restaurant and stripe
   order_canceled: 700, // by restaurant or user
   order_refunded: 800 // by restaurant
 };


### PR DESCRIPTION
PR827 に続く変更です。

1. customer_picked_up を ready_to_pickup に変更
2. transaction_complete という新たな状態を追加
3. 状態繊維が可能かどうかを possible_transitions というデータに記述して、クライアントとサーバーの両方で使うようにしました（これが結構大きな変更で、今回の変更で一番リスクの高い場所です）。

ちなみに、（PR827の時点で生じた問題ですが）副作用として、注文履歴を表示した時に、過去のものが「受け渡し準備完了」として表示されてしまいます。この問題を解決するのであれば、バッチを走らせて、ステータスが ready_to_pickup で、かつ、transaction_complete が存在するもの（新しいものには存在しません）を全て transaction_complete に変更してしまうのが良いかも。