### PR TITLE
Add transaction hide

### DIFF
--- a/functions/src/functions/order.ts
+++ b/functions/src/functions/order.ts
@@ -103,6 +103,7 @@ export const update = async (db: FirebaseFirestore.Firestore, data: any, context
         updatedAt: admin.firestore.Timestamp.now(),
         status
       };
+      // TODO: use constant timeEventMapping
       if (status === order_status.order_accepted) {
         props.timeEstimated = timeEstimated ?
           new admin.firestore.Timestamp(timeEstimated.seconds, timeEstimated.nanoseconds)
@@ -117,6 +118,9 @@ export const update = async (db: FirebaseFirestore.Firestore, data: any, context
         // Make it compatible with striped orders.
         props.orderCustomerPickedUpAt = admin.firestore.Timestamp.now();
         props.timeConfirmed = props.updatedAt;
+      }
+      if (status === order_status.transaction_hide) {
+        props.transactionHideAt = admin.firestore.Timestamp.now();
       }
       transaction.update(orderRef, props)
       return { success: true }

--- a/functions/src/functions/order.ts
+++ b/functions/src/functions/order.ts
@@ -1,7 +1,10 @@
 import * as functions from 'firebase-functions'
 import * as admin from 'firebase-admin';
 import * as utils from '../lib/utils'
-import { order_status, possible_transitions } from '../common/constant'
+import {
+  order_status, possible_transitions,
+  order_status_keys, timeEventMapping
+} from '../common/constant'
 import * as sms from './sms'
 import { resources } from './resources'
 import i18next from 'i18next'
@@ -99,28 +102,22 @@ export const update = async (db: FirebaseFirestore.Firestore, data: any, context
       }
 
       // everything are ok
+      const updateTimeKey = timeEventMapping[order_status_keys[status]];
+
       const props: any = {
         updatedAt: admin.firestore.Timestamp.now(),
-        status
+        status,
+        [updateTimeKey]: admin.firestore.Timestamp.now(),
       };
-      // TODO: use constant timeEventMapping
       if (status === order_status.order_accepted) {
         props.timeEstimated = timeEstimated ?
           new admin.firestore.Timestamp(timeEstimated.seconds, timeEstimated.nanoseconds)
           : order.timePlaced;
-        props.orderAcceptedAt = admin.firestore.Timestamp.now();
         order.timeEstimated = props.timeEstimated;
-      }
-      if (status === order_status.transaction_complete) {
-        props.transactionCompletedAt = admin.firestore.Timestamp.now();
       }
       if (status === order_status.ready_to_pickup) {
         // Make it compatible with striped orders.
         props.orderCustomerPickedUpAt = admin.firestore.Timestamp.now();
-        props.timeConfirmed = props.updatedAt;
-      }
-      if (status === order_status.transaction_hide) {
-        props.transactionHideAt = admin.firestore.Timestamp.now();
       }
       transaction.update(orderRef, props)
       return { success: true }

--- a/lang/en.json
+++ b/lang/en.json
@@ -359,6 +359,7 @@
       "cooking_completed": "Cooking Complete",
       "ready_to_pickup": "Ready to Pickup",
       "transaction_complete": "Pickup Complete",
+      "transaction_hide": "Transaction Complete",
       "order_canceled": "Canceled",
       "order_refunded": "Refunded"
     }

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -357,6 +357,8 @@
       "order_accepted": "Accepter",
       "cooking_completed": "Prêt à ramasser",
       "ready_to_pickup": "Complete",
+      "transaction_complete": "Ramassage terminé",
+      "transaction_hide": "Transaction terminée",
       "order_canceled": "Annulé",
       "order_refunded": "Remboursé"
     }

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -359,6 +359,7 @@
       "cooking_completed": "調理済み",
       "ready_to_pickup": "受け渡し準備完了",
       "transaction_complete": "受け渡し完了",
+      "transaction_hide": "受注処理完了",
       "order_canceled": "キャンセル済み",
       "order_refunded": "払い戻し済み"
     }

--- a/src/app/admin/Index.vue
+++ b/src/app/admin/Index.vue
@@ -170,6 +170,7 @@
                     :numberOfMenus="restaurantItem.numberOfMenus || 0"
                     :numberOfOrders="restaurantItem.numberOfOrders || 0"
                     :lineEnable="lines[restaurantItem.id] || false"
+                    :shopOwner="shopOwner"
                     ></restaurant-edit-card>
                 </div>
 
@@ -257,6 +258,7 @@ export default {
       news: newsList[0],
       unsetWarning: true,
       lines: {},
+      shopOwner: null,
     };
   },
   created() {
@@ -264,6 +266,7 @@ export default {
   },
   async mounted() {
     try {
+      this.shopOwner = await this.getShopOwner(this.$store.getters.uidAdmin);
       this.restaurant_detacher = db
         .collection("restaurants")
         .where("uid", "==", this.uid)

--- a/src/app/admin/OrderHistory.vue
+++ b/src/app/admin/OrderHistory.vue
@@ -142,7 +142,7 @@ export default {
       }
       const docs = (await query.get()).docs;
       this.last = docs.length == this.limit ? docs[this.limit - 1] : null;
-      const orders = docs.map(this.doc2data("order"));
+      const orders = docs.map(this.doc2data("order")).filter(a => a.status !== order_status.transaction_hide);
       orders.forEach(order => {
         order.timePlaced = order.timePlaced.toDate();
         if (order.timeEstimated) {

--- a/src/app/admin/OrderHistory.vue
+++ b/src/app/admin/OrderHistory.vue
@@ -72,12 +72,13 @@
               <span class="p-l-16 p-r-16">{{ $t('admin.order.more') }}</span>
             </b-button>
           </div>
-          <download-orders :orders="orders" />
+          <download-orders :orders="orders" v-if="shopOwner && !shopOwner.hidePrivacy" />
           <report-details
             :orders="orders"
             :fileName="fileName"
             :hideTable="true"
             :withStatus="true"
+            v-if="shopOwner && !shopOwner.hidePrivacy"
           />
         </div>
       </div>
@@ -111,7 +112,8 @@ export default {
       shopInfo: {},
       limit: 30,
       last: undefined,
-      orders: []
+      orders: [],
+      shopOwner: null,
     };
   },
   async created() {
@@ -124,6 +126,7 @@ export default {
       return;
     }
     this.shopInfo = restaurantDoc.data();
+    this.shopOwner = await this.getShopOwner(this.$store.getters.uidAdmin);
     this.next();
   },
   computed: {

--- a/src/app/admin/OrderInfoPage.vue
+++ b/src/app/admin/OrderInfoPage.vue
@@ -280,6 +280,7 @@ export default {
           if (order.exists) {
             const order_data = order.data();
             this.orderInfo = order_data;
+            console.log(order_data);
           }
         },
         error: error => {

--- a/src/app/admin/OrderInfoPage.vue
+++ b/src/app/admin/OrderInfoPage.vue
@@ -266,7 +266,7 @@ export default {
     };
   },
 
-  created() {
+  async created() {
     const restaurant_detacher = db
       .doc(`restaurants/${this.restaurantId()}`)
       .onSnapshot(restaurant => {
@@ -299,23 +299,12 @@ export default {
         }
       });
     this.detacher = [restaurant_detacher, menu_detacher, order_detacher];
+    this.shopOwner = await this.getShopOwner(this.$store.getters.uidAdmin);
   },
   destroyed() {
     this.detacher.map(detacher => {
       detacher();
     });
-  },
-  watch: {
-    async "shopInfo.uid"() {
-      if (this.shopInfo && this.shopInfo.uid) {
-        const admin = await db.doc(`/admins/${this.shopInfo.uid}`).get()
-        if (admin) {
-          this.shopOwner = admin.data();
-          return
-        }
-      }
-      this.showOwner = {hidePrivacy: false};
-    }
   },
   computed: {
     possibleTransitions() {

--- a/src/app/admin/OrderInfoPage.vue
+++ b/src/app/admin/OrderInfoPage.vue
@@ -38,7 +38,17 @@
       </div>
 
       <!-- Order Body Area -->
-      <div class="columns is-gapless">
+      <div class="columns is-gapless" v-if="orderInfo.status === order_status.transaction_hide">
+        <div class="column is-narrow w-24"></div>
+        <div class="column">
+          <div class="m-l-24 m-r-24">
+            <div class="bg-surface r-8 d-low p-l-24 p-r-24 p-t-24 p-b-24 m-t-24">
+              <div>{{ $t("order.status.transaction_hide") }}</div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div class="columns is-gapless" v-else>
         <!-- Left Gap -->
         <div class="column is-narrow w-24"></div>
 
@@ -438,7 +448,10 @@ export default {
           "ready_to_pickup",
           "transaction_complete"
         ];        ; // no longer "cooking_completed"
-    }
+    },
+    order_status() {
+      return order_status;
+    },
   },
   methods: {
     timeStampToText(timestamp) {

--- a/src/app/admin/OrderListPage.vue
+++ b/src/app/admin/OrderListPage.vue
@@ -204,7 +204,7 @@ export default {
       this.order_detacher = query.onSnapshot(result => {
         let orders = result.docs.map(this.doc2data("order"));
         orders = orders
-          .filter(a => a.status !== 1000)
+          .filter(a => a.status !== order_status.transaction_hide)
           .sort((order0, order1) => {
           if (order0.status === order1.status) {
             return (order0.timeEstimated || order0.timePlaced) >

--- a/src/app/admin/OrderListPage.vue
+++ b/src/app/admin/OrderListPage.vue
@@ -193,7 +193,7 @@ export default {
       this.order_detacher();
       let query = db
         .collection(`restaurants/${this.restaurantId()}/orders`)
-        .where("timePlaced", ">=", this.lastSeveralDays[this.dayIndex].date);
+          .where("timePlaced", ">=", this.lastSeveralDays[this.dayIndex].date)
       if (this.dayIndex > 0) {
         query = query.where(
           "timePlaced",
@@ -203,7 +203,9 @@ export default {
       }
       this.order_detacher = query.onSnapshot(result => {
         let orders = result.docs.map(this.doc2data("order"));
-        orders = orders.sort((order0, order1) => {
+        orders = orders
+          .filter(a => a.status !== 1000)
+          .sort((order0, order1) => {
           if (order0.status === order1.status) {
             return (order0.timeEstimated || order0.timePlaced) >
               (order1.timeEstimated || order1.timePlaced)

--- a/src/app/admin/Restaurant/RestaurantEditCard.vue
+++ b/src/app/admin/Restaurant/RestaurantEditCard.vue
@@ -114,7 +114,7 @@
       </div>
 
       <!-- Report Page -->
-      <div class="align-center m-t-16">
+      <div class="align-center m-t-16" v-if="shopOwner && !shopOwner.hidePrivacy">
         <b-button
           tag="nuxt-link"
           :to="`/admin/restaurants/${restaurantid}/report`"
@@ -199,6 +199,10 @@ export default {
   name: "RestaurantEditCard",
   props: {
     shopInfo: {
+      type: Object,
+      required: true
+    },
+    shopOwner: {
       type: Object,
       required: true
     },

--- a/src/assets/scss/orders.scss
+++ b/src/assets/scss/orders.scss
@@ -40,6 +40,13 @@
   border: 0;
 }
 
+.transaction_hide,
+.transaction_hide:hover {
+  @extend .c-status-purple;
+  @extend .bg-status-purple-bg;
+  border: 0;
+}
+
 .order_canceled,
 .order_canceled:hover {
   @extend .c-status-red;

--- a/src/plugins/constant.js
+++ b/src/plugins/constant.js
@@ -12,6 +12,11 @@ export const order_status = {
   transaction_hide: 1000, // special status
 };
 
+export const order_status_keys = Object.keys(order_status).reduce((tmp, key) => {
+  tmp[order_status[key]] = key;
+  return tmp;
+}, {});
+
 export const possible_transitions = {
   [order_status.order_placed]: {
     [order_status.order_accepted]: true,

--- a/src/plugins/constant.js
+++ b/src/plugins/constant.js
@@ -8,7 +8,8 @@ export const order_status = {
   ready_to_pickup: 600, // by restaurant and stripe
   transaction_complete: 650, // by restaurant (optional)
   order_canceled: 700, // by restaurant or user
-  order_refunded: 800 // by restaurant
+  order_refunded: 800, // by restaurant
+  transaction_hide: 1000, // special status
 };
 
 export const possible_transitions = {
@@ -23,7 +24,10 @@ export const possible_transitions = {
   [order_status.ready_to_pickup]: {
     [order_status.order_refunded]: true,
     [order_status.transaction_complete]: true
-  }
+  },
+  [order_status.transaction_complete]: {
+    [order_status.transaction_hide]: true
+  },
 };
 
 export const order_error = {
@@ -32,6 +36,17 @@ export const order_error = {
   payment_error: 300,
   order_canceled_by_restaurant: 400,
   unknow_error: 900
+};
+
+export const timeEventMapping = {
+  order_placed: "orderPlacedAt",
+  order_accepted: "orderAcceptedAt",
+  cooking_completed: "orderCookingCompletedAt",
+  ready_to_pickup: "timeConfirmed",
+  order_canceled_by_restaurant: "orderRestaurantCanceledAt",
+  order_canceled_by_customer: "orderCustomerCanceledAt",
+  transaction_complete: "transactionCompletedAt",
+  transaction_hide: "transactionHideAt",
 };
 
 export const stripe_regions = {

--- a/src/plugins/utils.js
+++ b/src/plugins/utils.js
@@ -4,6 +4,7 @@ import { ownPlateConfig } from "@/config/project";
 import { soundFiles, regionalSettings } from "~/plugins/constant.js";
 import moment from "moment";
 import * as Cookie from "cookie";
+import { db } from "~/plugins/firebase.js";
 
 import { defaultHeader } from "./header";
 
@@ -131,6 +132,13 @@ export default ({ app }) => {
           return (index >= 0) ? index : 0;
         }
         return 0;
+      },
+      async getShopOwner(uid) {
+        const admin = await db.doc(`/admins/${uid}`).get();
+        if (admin) {
+          return admin.data();
+        }
+        return {hidePrivacy: false};
       },
     },
     computed: {


### PR DESCRIPTION
admin/{uid}にhidePrivacyのフラグがある場合に、注文処理等の個人情報を隠せる変更の第一弾です。

「受注処理完了」の状態を追加しました。
後の変更で、「受注処理完了」になると注文が見えなくなるので、「受注処理完了」の表示部分は不要ですが、
最初のテストのために追加しました。

このPRの半分くらいが、オーダーのstatusを変更した時間を記録する、timeEventMapping周りのrefactoringです。
気になったのでいろいろと修正しました。