### PR TITLE
LP: move one of addButtons to the end of the page

### DIFF
--- a/src/app/user/lp.vue
+++ b/src/app/user/lp.vue
@@ -8,10 +8,10 @@
     <threeSteps />
     <askButtons />
     <communityIcons />
-    <askButtons />
     <mediaLink />
     <operators />
     <aboutService />
+    <askButtons />
     <news />
 
     <!-- Home Body Area -->


### PR DESCRIPTION
「ユーザー・コミュニティで助け合い」の直前にもaskButtonsがあってちょっと冗長に見えるのと、ページの最後にはaskButtonsは置いておいた方が良いと思い、ユーザー・コミュニティで助け合い」の後の askButtons を、ページ下（「このサービスについて」の下、「サービスからのお知らせ」の前）に移動しました。

