### PR TITLE
add api version 2

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -39,6 +39,10 @@
         "function": "api"
       },
       {
+        "source": "/api/2.0/**",
+        "function": "api"
+      },
+      {
         "source": "/sitemap.xml",
         "function": "api"
       },

--- a/functions/src/functions/apis2.ts
+++ b/functions/src/functions/apis2.ts
@@ -1,0 +1,133 @@
+import express from 'express';
+import * as admin from 'firebase-admin';
+// import { ownPlateConfig } from '../common/project';
+
+import moment from 'moment';
+
+export const apiRouter = express.Router();
+
+if (!admin.apps.length) {
+  admin.initializeApp();
+}
+
+let db = admin.firestore();
+
+export const updateDb = (_db) => {
+  db = _db;
+}
+
+export const response200 = (res, payload) => {
+  return res.json({
+    result: true,
+    payload,
+  });
+};
+
+//const hostname = "https://" + ownPlateConfig.hostName;
+
+const getRestaurantData = async (restaurantId) => {
+  const restaurant = await db.doc(`restaurants/${restaurantId}`).get();
+  if (!restaurant || !restaurant.exists) {
+    return null;
+  }
+  const restaurant_data: any = restaurant.data();
+  if (!restaurant_data.publicFlag || restaurant_data.deletedFlag) {
+    return null;
+  }
+  return restaurant_data;
+};
+
+const getRestaurantApiKey = async (restaurantId) => {
+  const apiKey = await db.doc(`restaurants/${restaurantId}/private/apikey`).get();
+  if (!apiKey || !apiKey.exists) {
+    return null;
+  }
+  const apiKeyData: any = apiKey.data();
+  return apiKeyData;
+};
+
+export const getRestaurant = async (req, res, next) => {
+  const { restaurantId } = req.params;
+
+  const restaurant_data = await getRestaurantData(restaurantId);
+  if (restaurant_data === null) {
+    return res.status(404).send("");
+  }
+  req.restaurant_data = restaurant_data;
+  req.restaurantId = restaurantId;
+  next();
+}
+export const apiKeyAuth = async (req, res, next) => {
+  const authorization = (req.headers['authorization']||"").split(" ")[1];
+  if (authorization === null || authorization === undefined) {
+    return res.status(401).send("");
+  }
+
+  const apiKey = await getRestaurantApiKey(req.restaurantId);
+  if (apiKey === null) {
+    return res.status(401).send("");
+  }
+  if (authorization !== apiKey.apikey) {
+    return res.status(401).send("");
+  }
+  next();
+};
+export const nameOfOrder = (order) => {
+  return (order && order.number !== undefined) ?
+    "#" + `00${order.number}`.slice(-3) : "";
+};
+
+
+// 日時、商品、数量、単価、金額、支払方法…といった情報です
+const getOrders = async (req: any, res: any) => {
+  const refRestaurant = db.doc(`restaurants/${req.restaurantId}`);
+  const orderCollection = await refRestaurant.collection('orders').orderBy("timeCreated", "desc").get();
+
+  try {
+    const orders = orderCollection.docs.map((item) => {
+      const order = item.data();
+      const menus = order.menuItems || {};
+
+      const items = Object.keys(order.order).reduce((tmp, menuId) => {
+        const __order  = order.order[menuId];
+        const menu = menus[menuId] || {};
+        (Array.isArray(__order) ? __order : [__order]).map((num, key) => {
+          const orderItem = {
+            menuId: menuId,
+            name: menu.itemName,
+            quantity: num,
+            options: ((order.options ||{})[menuId]||{})[key],
+            basePrice: menu.price,
+            // TODO: subtotal
+          } as any;
+          tmp.push(orderItem);
+        });
+        return tmp;
+      }, [] as any[]);
+      const ret = {
+        id: item.id,
+        name: nameOfOrder(order),
+        timeRequested: order.timePlaced && moment(order.timePlaced.toDate()).format("YYYY/MM/DD HH:mm"),
+        dateConfirmed: order.timeConfirmed && moment(order.timeConfirmed.toDate()).format("YYYY/MM/DD HH:mm"),
+        items,
+        payment: {
+          tax: order.tax,
+          tip: order.tip,
+          subTotal: order.sub_total,
+          total: order.totalCharge,
+          method: order.payment?.stripe ? "stripe" : "cash",
+        },
+        accounting: order.accounting,
+      };
+      return ret;
+    });
+    
+    return response200(res, {orders});
+  } catch (e) {  
+    console.log(e);
+    return res.status(500).send("");
+  }
+}
+
+
+apiRouter.get('/restaurants/:restaurantId/orders', getRestaurant, apiKeyAuth, getOrders);

--- a/functions/src/functions/express.ts
+++ b/functions/src/functions/express.ts
@@ -9,6 +9,7 @@ import * as utils from '../lib/utils'
 import * as stripeLog from '../lib/stripeLog';
 
 import * as apis from './apis';
+import * as apis2 from './apis2';
 
 import * as xmlbuilder from 'xmlbuilder';
 
@@ -27,6 +28,7 @@ let db = admin.firestore();
 export const updateDb = (_db) => {
   db = _db;
   apis.updateDb(db);
+  apis2.updateDb(db);
 }
 
 export const logger = async (req, res, next) => {
@@ -254,6 +256,7 @@ router.post('/stripe/callback',
 
 app.use('/1.0', router);
 app.use('/api/1.0/', apis.apiRouter);
+app.use('/api/2.0/', apis2.apiRouter);
 
 app.get('/r/:restaurantName', ogpPage);
 app.get('/r/:restaurantName/menus/:menuId', ogpPage);

--- a/functions/src/functions/order.ts
+++ b/functions/src/functions/order.ts
@@ -226,30 +226,6 @@ export const notifyCanceledOrder = async (db: FirebaseFirestore.Firestore, resta
   return notifyRestaurant(db, 'msg_order_canceled_by_user', restaurantId, orderId, restaurantName, orderNumber, lng)
 };
 
-export const getMenuObj = async (refRestaurant) => {
-  const menuObj = {};
-  const menusCollections = await refRestaurant.collection("menus").get();
-  menusCollections.forEach((m) => {
-    menuObj[m.id] = m.data();
-  });
-  return menuObj;
-};
-
-// const regex = /\((\+|\-)[0-9\.]+\)/
-const regex =  /\(((\+|\-|＋|ー|−)[0-9\.]+)\)/;
-
-const convPrice = (priceStr) => {
-  return Number(priceStr.replace(/ー|−/g, '-').replace(/＋/g, '+'));
-};
-
-const optionPrice = (option: string) => {
-  const match = option.match(regex);
-  if (match) {
-    return convPrice(match[1]);
-  }
-  return 0;
-}
-
 // export const wasOrderCreated = async (db, snapshot, context) => {
 export const wasOrderCreated = async (db, data: any, context) => {
   const uid = utils.validate_auth(context);
@@ -290,7 +266,7 @@ export const wasOrderCreated = async (db, data: any, context) => {
     const foodTax = restaurantData.foodTax || 0;
     const multiple = utils.getStripeRegion().multiple; //100 for USD, 1 for JPY
 
-    const menuObj = await getMenuObj(restaurantRef);
+    const menuObj = await utils.getMenuObj(restaurantRef);
 
     let food_sub_total = 0;
     let alcohol_sub_total = 0;
@@ -327,10 +303,10 @@ export const wasOrderCreated = async (db, data: any, context) => {
           const opt = menu.itemOptionCheckbox[key].split(",");
           if (opt.length === 1) {
             if (selectedOpt) {
-              return tmpPrice + Math.round(optionPrice(opt[0]) * multiple) / multiple;
+              return tmpPrice + Math.round(utils.optionPrice(opt[0]) * multiple) / multiple;
             }
           } else {
-            return tmpPrice + Math.round(optionPrice(opt[selectedOpt]) * multiple) / multiple;
+            return tmpPrice + Math.round(utils.optionPrice(opt[selectedOpt]) * multiple) / multiple;
           }
           return tmpPrice;
         }, menu.price);

--- a/functions/src/lib/utils.ts
+++ b/functions/src/lib/utils.ts
@@ -68,3 +68,27 @@ export const process_error = (error: any) => {
   }
   return new functions.https.HttpsError("internal", error.message, error);
 }
+
+// const regex = /\((\+|\-)[0-9\.]+\)/
+const regex =  /\(((\+|\-|＋|ー|−)[0-9\.]+)\)/;
+
+const convPrice = (priceStr) => {
+  return Number(priceStr.replace(/ー|−/g, '-').replace(/＋/g, '+'));
+};
+
+export const optionPrice = (option: string) => {
+  const match = option.match(regex);
+  if (match) {
+    return convPrice(match[1]);
+  }
+  return 0;
+}
+
+export const getMenuObj = async (refRestaurant) => {
+  const menuObj = {};
+  const menusCollections = await refRestaurant.collection("menus").get();
+  menusCollections.forEach((m) => {
+    menuObj[m.id] = m.data();
+  });
+  return menuObj;
+};

--- a/functions/tests/express_test.ts
+++ b/functions/tests/express_test.ts
@@ -45,8 +45,75 @@ describe('express function', () => {
     await adminDB.doc(`restaurants/testbar/menus/hoge`).set({
       images: {item: {resizedImages: {"600": "123.jpg"}}},
       itemDescription: "hello from menu",
+      price: 1000,
       itemName: "good menu",
     });
+    await adminDB.doc(`restaurants/testbar/menus/VbXMnx4wdTgh1VBpBRIr`).set({
+      images: {item: {resizedImages: {"600": "123.jpg"}}},
+      itemDescription: "hello from menu",
+      price: 1000,
+      itemName: "good menu",
+    });
+    await adminDB.doc(`restaurants/testbar/menus/DJHHNW17WqhT7O51lhxB`).set({
+      images: {item: {resizedImages: {"600": "123.jpg"}}},
+      itemDescription: "hello from menu",
+      price: 1000,
+      itemName: "good menu",
+      itemOptionCheckbox: [
+        "大盛り (+150),大盛り (+150),大盛り (+150),大盛り (+150),大盛り (+150),大盛り (+150),大盛り (+150),大盛り (+150),大盛り (0),大盛り (-150),",
+        "豆(+150), +ーAZaz09, 割引(ー130)",
+        "ひき肉 (+10),  チーズ, コーヒー",
+      ]
+    });
+    await adminDB.doc(`restaurants/testbar/private/apikey`).set({
+      apikey: "apiKeyMaster",
+    });
+    await adminDB.doc(`restaurants/testbar/orders/1212`).set(
+      {
+        "payment":{"stripe":"confirmed"},
+        "timePlaced": {"seconds":1611631800,"nanoseconds":904000000},
+        "totalCharge":1080,
+        "uid":"hdLfvObioAWvymcZsGlq5PKL0CX2",
+        "updatedAt":{"seconds":1611624589,"nanoseconds":130000000},
+        "timeConfirmed":{"seconds":1611624580,"nanoseconds":857000000},
+        "number":372,
+        "tip":0,
+        "orderAcceptedAt":{"seconds":1611624568,"nanoseconds":883000000},
+        "status":650,
+        "accounting":{
+          "food":{"tax":80,"revenue":1000},
+          "alcohol":{"tax":0,"revenue":0}},
+        "memo":"",
+        "rawOptions":{"VbXMnx4wdTgh1VBpBRIr":{"0":[]}},
+        "tax":80,
+        "orderPlacedAt":{"seconds":1611624550,"nanoseconds":383000000},
+        "phoneNumber":"+819011111111",
+        "timeEstimated":{"seconds":1611631800,"nanoseconds":904000000},
+        "options":{"VbXMnx4wdTgh1VBpBRIr":{"0":[]}},
+        "order":{"VbXMnx4wdTgh1VBpBRIr":[1]},
+        "inclusiveTax":false,
+        "name":"😃",
+        "sendSMS":true,
+        "timeCreated":{"seconds":1611624532,"nanoseconds":267000000},
+        "description":"#372 Test good fave 0333333333 ETsB5oBUQNMG53zA8K8P",
+        "menuItems":{"VbXMnx4wdTgh1VBpBRIr":{"price":1000,"itemName":"1212"}},
+        "transactionCompletedAt":{"seconds":1611624589,"nanoseconds":130000000},
+        "total":1080,
+        "sub_total":1000
+      });
+    await adminDB.doc(`restaurants/testbar/orders/12123`).set(
+      {"sendSMS":true,"tax":84,"sub_total":1051,"accounting":{"alcohol":{"revenue":0,"tax":0},"food":{"revenue":1051,"tax":84}},"updatedAt":{"seconds":1611624733,"nanoseconds":407000000},
+       "menuItems":{"DJHHNW17WqhT7O51lhxB":{"itemName":"aaa 炒めももの","price":741,"category1":"222"}},"memo":"","timePlaced":{"seconds":1611631800,"nanoseconds":996000000},"totalCharge":1135,"phoneNumber":"+819011111111",
+       "options": {
+         "DJHHNW17WqhT7O51lhxB": {
+           "0":["大盛り (+150)","豆(+150)","ひき肉 (+10)"]
+         }
+       },
+       "name":"😃",
+       "timeCreated":{"seconds":1611624725,"nanoseconds":303000000},
+       "order":{"DJHHNW17WqhT7O51lhxB":[1]},
+       "inclusiveTax":false,
+       "number":374,"status":300,"total":1135,"rawOptions":{"DJHHNW17WqhT7O51lhxB":{"0":[0,0,0]}},"uid":"hdLfvObioAWvymcZsGlq5PKL0CX2","tip":0,"orderPlacedAt":{"seconds":1611624733,"nanoseconds":407000000}});
   });
 
   it ('express simple test', async function() {
@@ -96,25 +163,19 @@ describe('express function', () => {
     meta_tag['og:site_name'].should.not.empty;
     meta_tag['og:type'].should.not.empty;
     meta_tag['og:image'].should.equal("https://example.com/images600");
-
-
   });
 
   it ('express sitemape test', async function() {
     const response = await request.get('/sitemap.xml');
     response.status.should.equal(200);
-
-    console.log(response.text);
-
+    // console.log(response.text);
   });
 
 
   it ('express api test', async function() {
     const response = await request.get('/api/1.0/restaurants').set("Origin", "http://localhost:3000");
     response.status.should.equal(200);
-
     console.log(response.headers['access-control-allow-origin']);
-
   });
 
 
@@ -167,4 +228,22 @@ describe('express function', () => {
     response.headers['access-control-allow-origin'].should.equal("https://test-aa.web.app");
   });
 
+  it ('express api key test', async function() {
+    const response = await request.get('/api/2.0/restaurants/testbar/orders')
+      .set("Authorization", "Bearer 123");
+    response.status.should.equal(401);
+  });
+  
+  it ('express api key test', async function() {
+    const response = await request.get('/api/2.0/restaurants/testbar/orders');
+    response.status.should.equal(401);
+  });
+
+  it ('express api key test', async function() {
+    const response = await request.get('/api/2.0/restaurants/testbar/orders')
+      .set("Authorization", "Bearer apiKeyMaster");
+    response.status.should.equal(200);
+    // console.log(JSON.stringify(JSON.parse(response.text), undefined, 1));
+  });
+  
 });


### PR DESCRIPTION
とりあえず最低限動くAPIです。

restaurants/${restaurantId}/private/apikey
にapikeyを入れて、authorizationヘッダーで認証します。

apikeyの発行の仕組みは最後に入れる予定です。
functionsで発行して、発行したときにしか見えないようにします。
apikeyはレストランごとに１つにして、なにか問題があっても削除 or 上書きで古いものは無効にする。

Todoとして、
-  request時のoption等 (limit, startAt, order等)
-  responseにorderのstatus(注文済み、受付済み、受け渡し完了等）
-  time~~~等の時間のデータが不足している。
等々、まだあります。

また、order::wasOrderCreatedで
itemごとに小計をいれて、それを返すようにしようと思います。


