### PR TITLE
Keep the level class in mobile view

### DIFF
--- a/src/app/user/RestaurantPage.vue
+++ b/src/app/user/RestaurantPage.vue
@@ -151,7 +151,7 @@
           </template>
           <template v-else="!noPaymentMethod">
             <div>
-              <div class="level t-subtitle1 c-text-white-full">
+              <div class="level is-mobile t-subtitle1 c-text-white-full">
                 <div class="level-left">
                   {{
                     $tc("sitemenu.orderCounter", totalQuantities, {


### PR DESCRIPTION
カートボタン内の .level でmobileにも適用するのを忘れていました。。（個数と値段の不要な改行を防ぎます）