### PR TITLE
Remove `VUE_APP_GAPIKey`

### DIFF
--- a/docs/setup-developer-env.md
+++ b/docs/setup-developer-env.md
@@ -104,8 +104,7 @@ cp src/config/default/ownplate-dev.ts src/config/project.ts
 # 9. start local server
 
 ```
-VUE_APP_CIRCLE_SHA1=123123 \
-VUE_APP_GAPIKey=xxxx yarn run start
+VUE_APP_CIRCLE_SHA1=123123 yarn run start
 ```
 
-# 10. Access your local-server 
+# 10. Access your local-server


### PR DESCRIPTION
`VUE_APP_GAPIKey` を渡さなくてもサーバが立ち上がった。

`VUE_APP_CIRCLE_SHA1` は [デバッグログ出力](https://github.com/Nakajima-Foundation/ownplate/blob/61603badcba3b90c159491668319170f7503ff90/src/components/App.vue#L556) で使われている。`VUE_APP_GAPIKey` はリポジトリ内で利用されている箇所を見つけられませんでした。
