### PR TITLE
add class in main.css

### DIFF
--- a/src/assets/css/main.css
+++ b/src/assets/css/main.css
@@ -161,6 +161,12 @@ canvas {
     display: inherit !important;
 }
 
-.control {
+/* 2024/10/04
+ * 以下のバージョンへあげた際のスタイル崩れを修正
+ * @oruga-ui/theme-bulma”: “^0.4.1"
+ * 影響箇所：input、textarea
+ * 対象画面：ログイン、店情報の変更、商品登録
+ */
+.field .control.has-icons-right {
   display: block !important;
 }

--- a/src/assets/css/main.css
+++ b/src/assets/css/main.css
@@ -160,3 +160,7 @@ canvas {
 .field .has-addons {
     display: inherit !important;
 }
+
+.control {
+  display: block !important;
+}


### PR DESCRIPTION
以下のバージョンへあげた際のスタイル崩れを修正
@oruga-ui/theme-bulma”: “^0.4.1"

影響箇所：input、textarea
影響画面：ログイン、店情報の変更、商品登録

以下の画面は別途要修正
注文確認のお店へのメッセージ、自動印刷、ディスカウント、デリバリー、スマレジ、サブアカウント