### PR TITLE
fix sidebar background-color

### DIFF
--- a/src/assets/css/main.css
+++ b/src/assets/css/main.css
@@ -170,3 +170,12 @@ canvas {
 .field .control.has-icons-right {
   display: block !important;
 }
+
+/* 2024/10/05
+ * 以下のバージョンへあげた際に色が黒っぽくなる現象を修正
+ * @oruga-ui/theme-bulma”: “^0.4.1"
+ * 影響箇所：サイドバーを開いたときの背景色
+ */
+.sidebar .sidebar-background {
+  background-color: #00000080!important;
+}


### PR DESCRIPTION
以下のバージョンへあげた際に色が黒っぽくなる現象を修正
@oruga-ui/theme-bulma”: “^0.4.1"

影響箇所：サイドバーを開いたときの背景色
