### PR TITLE
change success color to green

### DIFF
--- a/src/assets/css/main.css
+++ b/src/assets/css/main.css
@@ -184,7 +184,8 @@ canvas {
  * add for
  * @oruga-ui/theme-bulma”: “^0.4.1"
  * text color of success events
-*/
+ * ref: PhoneLogin.vue, PhoneEntry.vue
+ */
 .help.is-success {
   color: #16a34aff!important;
 }

--- a/src/assets/css/main.css
+++ b/src/assets/css/main.css
@@ -179,3 +179,12 @@ canvas {
 .sidebar .sidebar-background {
   background-color: #00000080!important;
 }
+
+/*
+ * add for
+ * @oruga-ui/theme-bulma”: “^0.4.1"
+ * text color of success events
+*/
+.help.is-success {
+  color: #16a34aff!important;
+}


### PR DESCRIPTION
 @oruga-ui/theme-bulma”: “^0.4.3"
Oruga UIののbulmaテーマのVupに伴い、
新バージョンで正常ケースのテキスト色がほとんど黒なので、旧バージョンと同じ緑色にする。
Oruga-UIを主にエラーケースに使用しており、正常ケースで使用している箇所はレアケースで PhoneLogin.vue, PhoneEntry.vueだけ。