### PR TITLE
fix alignment of <input> elements

### DIFF
--- a/src/app/user/OrderPage/BeforePaid/TimeToPickup.vue
+++ b/src/app/user/OrderPage/BeforePaid/TimeToPickup.vue
@@ -13,7 +13,7 @@
             <span v-if="day.offset === 0">{{ $t("date.today") }}</span>
           </option>
         </o-select>
-        <o-select v-model="time" class="mt-2">
+        <o-select v-model="time">
           <option
             v-for="(time, index) in availableDays[dayIndex].times"
             :value="time.time"


### PR DESCRIPTION
- The `TimeToPickup.vue` component is only used on this page
- THe `<time-to-pickup>` element is only used on this page

I am not sure why this margin was added. It was causing the design to break, so I removed it.