### PR TITLE
Remove dynamic links

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -85,10 +85,6 @@
           "region": "asia-northeast1"
         },
         {
-          "source": "/m/**",
-          "dynamicLinks": true
-        },
-        {
           "source": "**",
           "destination": "/index.html"
         }

--- a/src/app/m/ask.vue
+++ b/src/app/m/ask.vue
@@ -1,0 +1,20 @@
+<template>
+	<div>Redirecting...</div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from "vue";
+import { defaultTitle } from "@/utils/utils";
+import { useHead } from "@unhead/vue";
+
+export default defineComponent({
+  setup() {
+    useHead({
+      title: [defaultTitle, "Redirect"].join(" / "),
+    });
+  },
+  mounted() {
+    window.location.href = "https://docs.google.com/forms/d/e/1FAIpQLSfGR4kk65ynfkCRGJsvJz01HZf7AU1nGLL9Rn9i4G9-qiW6MQ/viewform";
+  }
+});
+</script>

--- a/src/app/m/kyuuya.vue
+++ b/src/app/m/kyuuya.vue
@@ -1,0 +1,21 @@
+<template>
+	<div>Redirecting...</div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from "vue";
+import { defaultTitle } from "@/utils/utils";
+import { useHead } from "@unhead/vue";
+
+export default defineComponent({
+  setup() {
+    useHead({
+      title: [defaultTitle, "Redirect"].join(" / "),
+    });
+  },
+	mounted() {
+		const currentOrigin = window.location.origin
+		window.location.href = `${currentOrigin}/r/5OInKqrhlpe7LHYNYXuU`
+  }
+});
+</script>

--- a/src/app/m/note.vue
+++ b/src/app/m/note.vue
@@ -1,0 +1,21 @@
+<template>
+	<div>Redirecting...</div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from "vue";
+import { defaultTitle } from "@/utils/utils";
+import { useHead } from "@unhead/vue";
+
+export default defineComponent({
+  setup() {
+    useHead({
+      title: [defaultTitle, "Redirect"].join(" / "),
+    });
+  },
+	mounted() {
+		const currentOrigin = window.location.origin
+		window.location.href = `${currentOrigin}?utm_source=web&utm_medium=note&utm_campaign=note`
+  }
+});
+</script>

--- a/src/lib/router.ts
+++ b/src/lib/router.ts
@@ -450,6 +450,18 @@ export const customRoutes: CustomRoute[] = [
     component: () => import("@/app/docs/link.vue"),
   },
   {
+		path: "/m/ask",
+		component: () => import("@/app/m/ask.vue"),
+	},
+  {
+		path: "/m/kyuuya",
+		component: () => import("@/app/m/kyuuya.vue"),
+	},
+  {
+		path: "/m/note",
+		component: () => import("@/app/m/note.vue"),
+	},
+  {
     path: "/:page(.*)",
     component: () => import("@/app/common/404.vue"),
   },


### PR DESCRIPTION
- firebase の dynamic links が使えなくなるので、まだ利用のあるページを個別に redirect するようにしました。
  - https://github.com/SingularitySociety/omochikaeri-docs/issues/118
- CustomRoute で component が必須になっていたので、router を使わずに、ページの中で直接 redirect するようにしました。