### PR TITLE
Update Content Security Policy headers for Stripe integration

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -27,7 +27,7 @@
           "headers": [
             {
               "key": "Content-Security-Policy",
-              "value": "frame-ancestors 'none'"
+              "value": "default-src 'self'; script-src 'self' 'unsafe-inline' https://js.stripe.com; style-src 'self' 'unsafe-inline' https://js.stripe.com; img-src 'self' data: https://js.stripe.com https://q.stripe.com; connect-src 'self' https://*.googleapis.com https://api.stripe.com https://*.stripe.com; frame-src 'self' https://js.stripe.com https://*.stripe.com; frame-ancestors 'none'"
             },
             { "key": "X-Frame-Options", "value": "deny" },
             { "key": "X-Content-Type-Options", "value": "nosniff" },


### PR DESCRIPTION
- Add data: image source support for Stripe base64 encoded images
- Add Stripe domains (js.stripe.com, q.stripe.com) to img-src, connect-src, and frame-src
- Maintain existing security controls while enabling Stripe 3D Secure authentication UI