### PR TITLE
Fix phone number utilities typo

### DIFF
--- a/functions/src/functions/notify/twilio.ts
+++ b/functions/src/functions/notify/twilio.ts
@@ -2,7 +2,7 @@ import twilio from "twilio";
 import { defineSecret } from "firebase-functions/params";
 
 import { twiml_neworder } from "../../common/constant";
-import { parsePhoneNumber, formatNational, intenationalFormat } from "../../common/phoneutil";
+import { parsePhoneNumber, formatNational, internationalFormat } from "../../common/phoneutil";
 import { enableNotification } from "../notificationConfig";
 
 const twilio_sid = defineSecret("TWILIO_SID");
@@ -18,10 +18,10 @@ export const parsedNumber = (restaurant) => {
   }
 };
 
-export const intenationalPhoneNumber = (restaurant) => {
+export const internationalPhoneNumber = (restaurant) => {
   const phoneNumber = parsedNumber(restaurant);
   if (phoneNumber) {
-    return intenationalFormat(phoneNumber);
+    return internationalFormat(phoneNumber);
   }
   return restaurant.phoneNumber;
 };
@@ -38,7 +38,7 @@ export const phoneCall = async (restaurant) => {
   if (!enableNotification) {
     return;
   }
-  const to = intenationalPhoneNumber(restaurant);
+  const to = internationalPhoneNumber(restaurant);
   if (!twilio_sid.value() || !twilio_token.value() || !twilio_phone_from.value()) {
     console.log("PhoneCall: no setting");
     return;

--- a/functions/tests/twilio_test.ts
+++ b/functions/tests/twilio_test.ts
@@ -31,7 +31,7 @@ describe("twilio function", () => {
     };
 
     if (test_phone_number) {
-      const num3 = twilio.intenationalPhoneNumber(restaurantCall);
+      const num3 = twilio.internationalPhoneNumber(restaurantCall);
       num3.should.startWith("+81");
 
       await twilio.phoneCall(restaurantCall);

--- a/src/utils/phoneutil.ts
+++ b/src/utils/phoneutil.ts
@@ -9,7 +9,7 @@ const phoneUtil = PhoneNumberUtil.getInstance();
 export const parsePhoneNumber = (phoneNumber: string): PhoneNumber => {
   return phoneUtil.parse(phoneNumber);
 };
-export const intenationalFormat = (parsedNumber: PhoneNumber): string => {
+export const internationalFormat = (parsedNumber: PhoneNumber): string => {
   return phoneUtil.format(parsedNumber, PhoneNumberFormat.INTERNATIONAL);
 };
 


### PR DESCRIPTION
## Summary
- fix typo `intenational` -> `international`
- update Twilio functions to use new function name
- adjust Twilio tests

## Testing
- `npm test` *(fails: Missing script)*
- `npm --prefix functions run tests` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864b0497d088333b64ef163e40dadf3