### PR TITLE
Fix typo in order update validator

### DIFF
--- a/functions/src/functions/order/orderUpdate.ts
+++ b/functions/src/functions/order/orderUpdate.ts
@@ -8,7 +8,7 @@ import { sendMessageToCustomer } from "../notify2";
 
 import { getStripeAccount, getStripeOrderRecord, getHash } from "../stripe/intent";
 import { orderUpdateData, updateDataOnorderUpdate } from "../../lib/types";
-import { validateOrderUpadte } from "../../lib/validator";
+import { validateOrderUpdate } from "../../lib/validator";
 
 const getMgsKey = (status: number, isEC: boolean, timeEstimated?: admin.firestore.Timestamp) => {
   if (status === order_status.order_accepted) {
@@ -64,7 +64,7 @@ export const update = async (db: admin.firestore.Firestore, data: orderUpdateDat
   const { restaurantId, orderId, status, timeEstimated } = data;
   utils.required_params({ restaurantId, orderId, status });
 
-  const validateResult = validateOrderUpadte(data);
+  const validateResult = validateOrderUpdate(data);
   if (!validateResult.result) {
     console.error("orderUpdate", validateResult.errors);
     throw new HttpsError("invalid-argument", "Validation Error.");

--- a/functions/src/lib/validator.ts
+++ b/functions/src/lib/validator.ts
@@ -197,7 +197,7 @@ export const validateOrderCreated = (data: orderCreatedData) => {
   return validateData(data, validator);
 };
 
-export const validateOrderUpadte = (data: orderUpdateData) => {
+export const validateOrderUpdate = (data: orderUpdateData) => {
   const validator = {
     restaurantId: {
       type: "firebaseId",

--- a/functions/tests/validator_test.ts
+++ b/functions/tests/validator_test.ts
@@ -14,7 +14,7 @@ describe("validator function", () => {
       // lng?: string;
       //timeEstimated?: admin.firestore.Timestamp;
     };
-    const res = validator.validateOrderUpadte(data);
+    const res = validator.validateOrderUpdate(data);
     res.result.should.equal(true);
   });
 


### PR DESCRIPTION
## Summary
- rename `validateOrderUpadte` to `validateOrderUpdate`
- update references in order update handler and unit tests

## Testing
- `yarn --cwd functions run validator_tests` *(fails: package not in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_6864b1662a188333938e634ac1918779