### PR TITLE
refactor: use dialog store for errors

### DIFF
--- a/src/app/admin/Index.vue
+++ b/src/app/admin/Index.vue
@@ -291,7 +291,7 @@ import { checkAdminPermission } from "@/utils/userPermission";
 
 import { useAdminConfigToggle } from "@/utils/admin/Toggle";
 
-import { useStore } from "vuex";
+import { useDialogStore } from "@/store/dialog";
 import { useRouter } from "vue-router";
 
 import { RestaurantInfoData } from "@/models/RestaurantInfo";
@@ -317,7 +317,7 @@ export default defineComponent({
     ToggleSwitch,
   },
   setup() {
-    const store = useStore();
+    const dialogStore = useDialogStore();
     const router = useRouter();
 
     const readyToDisplay = ref(false);
@@ -551,7 +551,7 @@ export default defineComponent({
 
           router.push(`/admin/restaurants/${newDoc.id}`);
         } catch (error) {
-          store.commit("setErrorMessage", {});
+          dialogStore.setErrorMessage({} as any);
           console.log(error);
         }
       }

--- a/src/app/admin/Index/PaymentSection.vue
+++ b/src/app/admin/Index/PaymentSection.vue
@@ -113,6 +113,7 @@ import {
 import { useStore } from "vuex";
 import { useGeneralStore } from "@/store";
 import { useRoute, useRouter } from "vue-router";
+import { useDialogStore } from "@/store/dialog";
 
 import { db } from "@/lib/firebase/firebase9";
 import { doc, onSnapshot, Unsubscribe, setDoc } from "firebase/firestore";
@@ -135,6 +136,7 @@ export default defineComponent({
     const generalStore = useGeneralStore();
     const route = useRoute();
     const router = useRouter();
+    const dialogStore = useDialogStore();
 
     const paymentInfo = ref<PaymentInfo>({}); // { stripe, inStore, ... }
     let stripe_connnect_detacher: Unsubscribe | null = null;
@@ -153,10 +155,10 @@ export default defineComponent({
             console.log(data);
           } catch (error: any) {
             console.error(error);
-            store.commit("setErrorMessage", {
+            dialogStore.setErrorMessage({
               code: "stripe.connect",
               error,
-            });
+            } as any);
           } finally {
             generalStore.setLoading(false);
             router.replace(location.pathname);
@@ -240,10 +242,10 @@ export default defineComponent({
             // TODO: show connected view
           } catch (error: any) {
             console.error(error, error.details);
-            store.commit("setErrorMessage", {
+            dialogStore.setErrorMessage({
               code: "stripe.disconnect",
               error,
-            });
+            } as any);
           } finally {
             generalStore.setLoading(false);
           }

--- a/src/app/admin/Order/CancelModal.vue
+++ b/src/app/admin/Order/CancelModal.vue
@@ -73,8 +73,8 @@ import { OrderInfoData } from "@/models/orderInfo";
 import { RestaurantInfoData } from "@/models/RestaurantInfo";
 import ButtonLoading from "@/components/form/Loading.vue";
 
-import { useStore } from "vuex";
 import { useRouter } from "vue-router";
+import { useDialogStore } from "@/store/dialog";
 
 export default defineComponent({
   props: {
@@ -110,7 +110,7 @@ export default defineComponent({
   emits: ["close"],
   setup(props, ctx) {
     const router = useRouter();
-    const store = useStore();
+    const dialogStore = useDialogStore();
 
     const updating = ref(false);
 
@@ -133,10 +133,10 @@ export default defineComponent({
         router.push(props.parentUrl);
       } catch (error: any) {
         console.error(error.message, error.details);
-        store.commit("setErrorMessage", {
+        dialogStore.setErrorMessage({
           code: "order.cancel",
           error,
-        });
+        } as any);
       } finally {
         updating.value = false;
       }

--- a/src/app/admin/Order/PaymentCancelModal.vue
+++ b/src/app/admin/Order/PaymentCancelModal.vue
@@ -67,8 +67,8 @@ import { defineComponent, ref } from "vue";
 import { stripePaymentCancelIntent } from "@/lib/firebase/functions";
 
 import { useGeneralStore } from "@/store";
-import { useStore } from "vuex";
 import { useRouter } from "vue-router";
+import { useDialogStore } from "@/store/dialog";
 
 export default defineComponent({
   props: {
@@ -100,8 +100,8 @@ export default defineComponent({
   emits: ["close"],
   setup(props, ctx) {
     const router = useRouter();
-    const store = useStore();
     const generalStore = useGeneralStore();
+    const dialogStore = useDialogStore();
 
     const updating = ref(false);
     const handlePaymentCancel = async () => {
@@ -118,10 +118,10 @@ export default defineComponent({
         router.push(props.parentUrl);
       } catch (error: any) {
         console.error(error.message, error.details);
-        store.commit("setErrorMessage", {
+        dialogStore.setErrorMessage({
           code: "stripe.cancel",
           error,
-        });
+        } as any);
       } finally {
         updating.value = false;
         generalStore.setLoading(false);

--- a/src/app/admin/Restaurants/Index.vue
+++ b/src/app/admin/Restaurants/Index.vue
@@ -1406,10 +1406,10 @@ export default defineComponent({
           location.reload();
         }, 200);
       } catch (error) {
-        store.commit("setErrorMessage", {
+        dialogStore.setErrorMessage({
           code: "restaurant.save",
           error,
-        });
+        } as any);
       }
     };
     const confirmCopy = () => {
@@ -1456,10 +1456,10 @@ export default defineComponent({
         router.push(`/admin/restaurants/#restaurant_` + restaurantId.value);
       } catch (error) {
         submitting.value = false;
-        store.commit("setErrorMessage", {
+        dialogStore.setErrorMessage({
           code: "restaurant.save",
           error,
-        });
+        } as any);
       }
     };
     const updateMap = async () => {

--- a/src/app/admin/Restaurants/MenuItemPage.vue
+++ b/src/app/admin/Restaurants/MenuItemPage.vue
@@ -1021,10 +1021,10 @@ export default defineComponent({
         });
       } catch (error) {
         submitting.value = false;
-        store.commit("setErrorMessage", {
+        dialogStore.setErrorMessage({
           code: "menu.save",
           error,
-        });
+        } as any);
         console.log(error);
       }
     };

--- a/src/app/admin/Restaurants/OrderInfoPage.vue
+++ b/src/app/admin/Restaurants/OrderInfoPage.vue
@@ -577,6 +577,7 @@ import {
 import { useStore } from "vuex";
 import { useGeneralStore } from "@/store";
 import { useRoute, useRouter } from "vue-router";
+import { useDialogStore } from "@/store/dialog";
 
 import { useI18n } from "vue-i18n";
 import { useHead } from "@unhead/vue";
@@ -610,6 +611,7 @@ export default defineComponent({
   setup(props) {
     const store = useStore();
     const generalStore = useGeneralStore();
+    const dialogStore = useDialogStore();
     const route = useRoute();
     const router = useRouter();
     const { d } = useI18n({ useScope: "global" });
@@ -1048,22 +1050,22 @@ export default defineComponent({
           router.push(parentUrl.value);
         } else {
           if (data.type === "StripeCardError") {
-            store.commit("setErrorMessage", {
+            dialogStore.setErrorMessage({
               code: "order.updateCard",
               message2: "errorPage.message.cardError",
-            });
+            } as any);
           } else {
-            store.commit("setErrorMessage", {
+            dialogStore.setErrorMessage({
               code: "order.update",
-            });
+            } as any);
           }
         }
       } catch (error: any) {
         console.error(error.message, error.details);
-        store.commit("setErrorMessage", {
+        dialogStore.setErrorMessage({
           code: "order.update",
           error,
-        });
+        } as any);
       } finally {
         generalStore.setLoading(false);
         updating.value = "";
@@ -1089,10 +1091,10 @@ export default defineComponent({
             // console.log("update", data);
           } catch (error: any) {
             console.error(error.message, error.details);
-            store.commit("setErrorMessage", {
+            dialogStore.setErrorMessage({
               code: "order.update",
               error,
-            });
+            } as any);
           } finally {
             generalStore.setLoading(false);
             changing.value = false;

--- a/src/app/auth/LineCallback.vue
+++ b/src/app/auth/LineCallback.vue
@@ -17,6 +17,7 @@ import { lineValidate } from "@/lib/firebase/functions";
 import { useUserData } from "@/utils/utils";
 import { useRoute, useRouter } from "vue-router";
 import { useStore } from "vuex";
+import { useDialogStore } from "@/store/dialog";
 import Loading from "@/components/Loading.vue";
 
 export default defineComponent({
@@ -27,6 +28,7 @@ export default defineComponent({
     const router = useRouter();
     const route = useRoute();
     const store = useStore();
+    const dialogStore = useDialogStore();
 
     const code = route.query.code as string;
     const restaurantId = route.params.restaurantId as string | undefined;
@@ -78,11 +80,11 @@ export default defineComponent({
           }
         } catch (error: any) {
           console.error(error.message, error.details);
-          store.commit("setErrorMessage", {
+          dialogStore.setErrorMessage({
             code: "line.validation",
             message2: "errorPage.message.line",
             error,
-          });
+          } as any);
         } finally {
           isValidating.value = false;
         }

--- a/src/app/user/OrderPage/AfterPaid.vue
+++ b/src/app/user/OrderPage/AfterPaid.vue
@@ -233,6 +233,7 @@ import { RestaurantInfoData } from "@/models/RestaurantInfo";
 import { useRoute } from "vue-router";
 import { useStore } from "vuex";
 import { useGeneralStore } from "@/store";
+import { useDialogStore } from "@/store/dialog";
 import { useI18n } from "vue-i18n";
 
 export default defineComponent({
@@ -290,6 +291,7 @@ export default defineComponent({
     const route = useRoute();
     const store = useStore();
     const generalStore = useGeneralStore();
+    const dialogStore = useDialogStore();
     const { d } = useI18n({ useScope: "global" });
 
     const orderId = route.params.orderId as string;
@@ -359,10 +361,10 @@ export default defineComponent({
           } catch (error) {
             // BUGBUG: Implement the error handling code here
             // console.error(error.message, error.details);
-            store.commit("setErrorMessage", {
+            dialogStore.setErrorMessage({
               code: "order.cancel",
               error,
-            });
+            } as any);
           } finally {
             generalStore.setLoading(false);
             isCancelling.value = false;

--- a/src/app/user/OrderPage/BeforePaid.vue
+++ b/src/app/user/OrderPage/BeforePaid.vue
@@ -385,9 +385,9 @@ import * as analyticsUtil from "@/lib/firebase/analytics";
 
 import { useHasSoldOutToday } from "./Stock";
 
-import { useStore } from "vuex";
 import { useGeneralStore } from "@/store";
 import { useCartStore } from "@/store/cart";
+import { useDialogStore } from "@/store/dialog";
 import { useRoute } from "vue-router";
 
 export default defineComponent({
@@ -443,9 +443,9 @@ export default defineComponent({
   emits: ["handleOpenMenu", "openTransactionsAct"],
   setup(props, ctx) {
     const route = useRoute();
-    const store = useStore();
     const generalStore = useGeneralStore();
     const cartStore = useCartStore();
+    const dialogStore = useDialogStore();
 
     const restaurantId = route.params.restaurantId as string;
 
@@ -655,10 +655,10 @@ export default defineComponent({
       } catch (error: any) {
         // alert(JSON.stringify(error));
         console.error(error.message, error.details);
-        store.commit("setErrorMessage", {
+        dialogStore.setErrorMessage({
           code: "order.place",
           error,
-        });
+        } as any);
       } finally {
         generalStore.setLoading(false);
       }

--- a/src/app/user/OrderPage/Pay.vue
+++ b/src/app/user/OrderPage/Pay.vue
@@ -119,9 +119,9 @@ import { RestaurantInfoData } from "@/models/RestaurantInfo";
 
 import * as analyticsUtil from "@/lib/firebase/analytics";
 
-import { useStore } from "vuex";
 import { useGeneralStore } from "@/store";
 import { useCartStore } from "@/store/cart";
+import { useDialogStore } from "@/store/dialog";
 import { useRoute } from "vue-router";
 
 export default defineComponent({
@@ -162,9 +162,9 @@ export default defineComponent({
   },
   setup(props) {
     const route = useRoute();
-    const store = useStore();
     const generalStore = useGeneralStore();
     const cartStore = useCartStore();
+    const dialogStore = useDialogStore();
 
     const restaurantId = route.params.restaurantId as string;
 
@@ -239,10 +239,10 @@ export default defineComponent({
         window.scrollTo(0, 0);
       } catch (error: any) {
         console.error(error.message, error.details);
-        store.commit("setErrorMessage", {
+        dialogStore.setErrorMessage({
           code: "order.place",
           error,
-        });
+        } as any);
       } finally {
         generalStore.setLoading(false);
       }

--- a/src/app/user/RestaurantPage.vue
+++ b/src/app/user/RestaurantPage.vue
@@ -335,6 +335,7 @@ import { useTitles, useMenu } from "./Restaurant/Utils";
 import { useStore } from "vuex";
 import { useGeneralStore } from "@/store";
 import { useCartStore } from "@/store/cart";
+import { useDialogStore } from "@/store/dialog";
 
 import { useRoute, useRouter } from "vue-router";
 
@@ -394,6 +395,7 @@ export default defineComponent({
     const store = useStore();
     const generalStore = useGeneralStore();
     const cartStore = useCartStore();
+    const dialogStore = useDialogStore();
     const route = useRoute();
     const router = useRouter();
 
@@ -723,10 +725,10 @@ export default defineComponent({
           }, 500);
         } else {
           console.error(error.message);
-          store.commit("setErrorMessage", {
+          dialogStore.setErrorMessage({
             code: "order.checkout",
             error,
-          });
+          } as any);
         }
       } finally {
         generalStore.setLoading(false);

--- a/src/components/DialogBox.vue
+++ b/src/components/DialogBox.vue
@@ -65,16 +65,15 @@
 import { defineComponent, computed } from "vue";
 import * as Sentry from "@sentry/vue";
 
-import { useStore } from "vuex";
+import { useDialogStore } from "@/store/dialog";
 import { useI18n } from "vue-i18n";
 
 export default defineComponent({
   setup() {
     const { t } = useI18n({ useScope: "global" });
-    const store = useStore();
-
+    const dialogStore = useDialogStore();
     const dialog = computed(() => {
-      return store.state.dialog;
+      return dialogStore.dialog;
     });
 
     const alert = computed(() => {
@@ -99,7 +98,7 @@ export default defineComponent({
       return error.value.message2 || "errorPage.message.generic";
     });
     const close = () => {
-      store.commit("resetDialog");
+      dialogStore.resetDialog();
     };
     const handleYes = () => {
       console.log("handleYes");


### PR DESCRIPTION
## Summary
- use Pinia dialog store instead of Vuex commits for error dialogs
- update DialogBox to read/reset dialog store

## Testing
- `yarn lint && echo 'lint ok'`

------
https://chatgpt.com/codex/tasks/task_e_689aefa582188333be2d9e3cbe3ff291