### PR TITLE
refactor: replace Vuex setAlert with dialog store

### DIFF
--- a/src/app/admin/Index/PaymentSection.vue
+++ b/src/app/admin/Index/PaymentSection.vue
@@ -233,7 +233,7 @@ export default defineComponent({
       location.href = `https://connect.stripe.com/oauth/authorize?${queryString}`;
     };
     const handlePaymentAccountDisconnect = () => {
-      store.commit("setAlert", {
+      dialogStore.setAlert({
         code: "admin.payments.reallyDisconnectStripe",
         callback: async () => {
           try {

--- a/src/app/admin/Index/Restaurant.vue
+++ b/src/app/admin/Index/Restaurant.vue
@@ -405,6 +405,7 @@ import {
 } from "firebase/firestore";
 
 import { useStore } from "vuex";
+import { useDialogStore } from "@/store/dialog";
 
 import { resizedProfileImage, isDev } from "@/utils/utils";
 
@@ -447,6 +448,7 @@ export default defineComponent({
   emits: ["positionUp", "positionDown", "deleteFromRestaurantLists"],
   setup(props, ctx) {
     const store = useStore();
+    const dialogStore = useDialogStore();
 
     const requestState = ref(0);
     let detacher: null | Unsubscribe = null;
@@ -470,7 +472,7 @@ export default defineComponent({
     });
 
     const deleteRestaurant = () => {
-      store.commit("setAlert", {
+      dialogStore.setAlert({
         title: props.shopInfo.restaurantName,
         code: "editRestaurant.reallyDelete",
         callback: () => {
@@ -483,7 +485,7 @@ export default defineComponent({
       });
     };
     const deleteFromList = () => {
-      store.commit("setAlert", {
+      dialogStore.setAlert({
         code: "editRestaurant.reallyOnListDelete",
         callback: () => {
           updateDoc(doc(db, `restaurants/${props.restaurantid}`), {

--- a/src/app/admin/Messages/MessageCard.vue
+++ b/src/app/admin/Messages/MessageCard.vue
@@ -38,8 +38,8 @@ import {
   subAccountInvitationDeny,
 } from "@/lib/firebase/functions";
 
-import { useStore } from "vuex";
 import { useGeneralStore } from "@/store";
+import { useDialogStore } from "@/store/dialog";
 import { useRouter, useRoute } from "vue-router";
 
 import moment from "moment-timezone";
@@ -54,13 +54,13 @@ export default defineComponent({
   },
 
   setup(props) {
-    const store = useStore();
     const generalStore = useGeneralStore();
+    const dialogStore = useDialogStore();
     const router = useRouter();
     const route = useRoute();
 
     const childInvitationAccept = () => {
-      store.commit("setAlert", {
+      dialogStore.setAlert({
         title: "admin.messages.childInvitationAccept",
         code: "admin.messages.childInvitationAcceptMessage",
         callback: async () => {
@@ -76,7 +76,7 @@ export default defineComponent({
     };
     const childInvitationDeny = () => {
       console.log("deny");
-      store.commit("setAlert", {
+      dialogStore.setAlert({
         code: "admin.messages.childInvitationDeny",
         callback: async () => {
           generalStore.setLoading(true);

--- a/src/app/admin/Restaurants/Index.vue
+++ b/src/app/admin/Restaurants/Index.vue
@@ -1133,7 +1133,6 @@ import {
   GOOGLE_MAP_DEFAULT_CENTER,
 } from "@/config/constant";
 
-import { useStore } from "vuex";
 import { useDialogStore } from "@/store/dialog";
 import { useRouter } from "vue-router";
 import { useHead } from "@unhead/vue";
@@ -1164,7 +1163,6 @@ export default defineComponent({
     },
   },
   setup(props) {
-    const store = useStore();
     const dialogStore = useDialogStore();
     const router = useRouter();
 
@@ -1413,7 +1411,7 @@ export default defineComponent({
       }
     };
     const confirmCopy = () => {
-      store.commit("setAlert", {
+      dialogStore.setAlert({
         code: "editCommon.copyAlert",
         callback: () => {
           copyRestaurantFunc();

--- a/src/app/admin/Restaurants/ManageLine.vue
+++ b/src/app/admin/Restaurants/ManageLine.vue
@@ -109,7 +109,7 @@ import {
 import NotFound from "@/components/NotFound.vue";
 import AdminHeader from "@/app/admin/AdminHeader.vue";
 
-import { useStore } from "vuex";
+import { useDialogStore } from "@/store/dialog";
 import { useRouter, useRoute } from "vue-router";
 import { useHead } from "@unhead/vue";
 interface LineUserData {
@@ -129,7 +129,7 @@ export default defineComponent({
     },
   },
   setup(props) {
-    const store = useStore();
+    const dialogStore = useDialogStore();
     const router = useRouter();
     const route = useRoute();
 
@@ -199,7 +199,7 @@ export default defineComponent({
       location.href = url;
     };
     const handleDelete = (_lineId: string) => {
-      store.commit("setAlert", {
+      dialogStore.setAlert({
         code: "admin.order.lineDelete",
         callback: async () => {
           console.log("handleDelete", _lineId);

--- a/src/app/admin/Restaurants/MenuItemPage.vue
+++ b/src/app/admin/Restaurants/MenuItemPage.vue
@@ -952,7 +952,7 @@ export default defineComponent({
           (r) => r.id === copyRestaurantId.value,
         );
         if (shop) {
-          store.commit("setAlert", {
+          dialogStore.setAlert({
             title: shop.restaurantName,
             code: "editCommon.copyMenuAlert",
             callback: async () => {

--- a/src/app/admin/Restaurants/MenuListPage/Menu.vue
+++ b/src/app/admin/Restaurants/MenuListPage/Menu.vue
@@ -149,8 +149,8 @@ import {
   useRestaurantId,
 } from "@/utils/utils";
 
-import { useStore } from "vuex";
 import { useGeneralStore } from "@/store";
+import { useDialogStore } from "@/store/dialog";
 
 import { useRouter } from "vue-router";
 import moment from "moment-timezone";
@@ -176,9 +176,9 @@ export default defineComponent({
   },
   emits: ["toEditMode", "positionUp", "positionDown", "forkItem", "deleteItem"],
   setup(props, ctx) {
-    const store = useStore();
     const router = useRouter();
     const generalStore = useGeneralStore();
+    const dialogStore = useDialogStore();
 
     const restaurantId = useRestaurantId();
 
@@ -225,7 +225,7 @@ export default defineComponent({
       ctx.emit("forkItem", props.menuitem.id);
     };
     const deleteItem = () => {
-      store.commit("setAlert", {
+      dialogStore.setAlert({
         code: "editMenu.reallyDelete",
         callback: () => {
           ctx.emit("deleteItem", props.menuitem.id);

--- a/src/app/admin/Restaurants/MenuListPage/Title.vue
+++ b/src/app/admin/Restaurants/MenuListPage/Title.vue
@@ -92,7 +92,7 @@
 import { defineComponent } from "vue";
 import { useAdminUids } from "@/utils/utils";
 
-import { useStore } from "vuex";
+import { useDialogStore } from "@/store/dialog";
 import TitleInput from "@/app/admin/Restaurants/MenuListPage/TitleInput.vue";
 import Checkbox from "@/components/form/checkbox.vue";
 
@@ -125,7 +125,7 @@ export default defineComponent({
     "updateTitleLunchDinner",
   ],
   setup(props, ctx) {
-    const store = useStore();
+    const dialogStore = useDialogStore();
 
     const { isOwner } = useAdminUids();
     const toEdit = () => {
@@ -142,7 +142,7 @@ export default defineComponent({
       ctx.emit("forkItem", props.title.id);
     };
     const deleteItem = () => {
-      store.commit("setAlert", {
+      dialogStore.setAlert({
         code: "editMenu.reallyDelete",
         callback: () => {
           ctx.emit("deleteItem", props.title.id);

--- a/src/app/admin/Restaurants/OrderInfoPage.vue
+++ b/src/app/admin/Restaurants/OrderInfoPage.vue
@@ -1072,7 +1072,7 @@ export default defineComponent({
       }
     };
     const handleOrderChange = () => {
-      store.commit("setAlert", {
+      dialogStore.setAlert({
         title: "admin.order.confirmOrderChange",
         code: "admin.order.updateOrderMessage",
         callback: async () => {

--- a/src/app/admin/SubAccounts/Accounts.vue
+++ b/src/app/admin/SubAccounts/Accounts.vue
@@ -181,8 +181,8 @@ import { doc2data, array2obj, useAdminUids, defaultTitle } from "@/utils/utils";
 import BackButton from "@/components/BackButton.vue";
 import { RestaurantInfoData } from "@/models/RestaurantInfo";
 
-import { useStore } from "vuex";
 import { useGeneralStore } from "@/store";
+import { useDialogStore } from "@/store/dialog";
 import { useRouter } from "vue-router";
 import { useHead } from "@unhead/vue";
 import moment from "moment";
@@ -192,8 +192,8 @@ export default defineComponent({
     BackButton,
   },
   setup() {
-    const store = useStore();
     const generalStore = useGeneralStore();
+    const dialogStore = useDialogStore();
     const router = useRouter();
 
     const restaurantObj = ref<{ [key: string]: RestaurantInfoData }>({});
@@ -251,7 +251,7 @@ export default defineComponent({
     });
 
     const deleteChild = (childId: string) => {
-      store.commit("setAlert", {
+      dialogStore.setAlert({
         code: "admin.subAccounts.confirmDeletechild",
         callback: async () => {
           generalStore.setLoading(true);

--- a/src/app/user/OrderPage/AfterPaid.vue
+++ b/src/app/user/OrderPage/AfterPaid.vue
@@ -231,7 +231,6 @@ import { OrderInfoData } from "@/models/orderInfo";
 import { RestaurantInfoData } from "@/models/RestaurantInfo";
 
 import { useRoute } from "vue-router";
-import { useStore } from "vuex";
 import { useGeneralStore } from "@/store";
 import { useDialogStore } from "@/store/dialog";
 import { useI18n } from "vue-i18n";
@@ -289,7 +288,6 @@ export default defineComponent({
   },
   setup(props) {
     const route = useRoute();
-    const store = useStore();
     const generalStore = useGeneralStore();
     const dialogStore = useDialogStore();
     const { d } = useI18n({ useScope: "global" });
@@ -346,7 +344,7 @@ export default defineComponent({
       analyticsUtil.sendRedunded(props.orderInfo, orderId, props.shopInfo);
     };
     const handleCancelPayment = () => {
-      store.commit("setAlert", {
+      dialogStore.setAlert({
         code: "order.cancelOrderConfirm",
         callback: async () => {
           try {

--- a/src/app/user/Profile/DeleteAccount.vue
+++ b/src/app/user/Profile/DeleteAccount.vue
@@ -38,7 +38,7 @@ import { getAuth, deleteUser } from "firebase/auth";
 import { accountDelete } from "@/lib/firebase/functions";
 import { useUserData } from "@/utils/utils";
 
-import { useStore } from "vuex";
+import { useDialogStore } from "@/store/dialog";
 
 export default defineComponent({
   components: {
@@ -46,14 +46,14 @@ export default defineComponent({
     Loading,
   },
   setup() {
-    const store = useStore();
+    const dialogStore = useDialogStore();
     const { user } = useUserData();
 
     const isDeletingAccount = ref(false);
     const reLoginVisible = ref(false);
 
     const handleDeleteAccount = () => {
-      store.commit("setAlert", {
+      dialogStore.setAlert({
         code: "profile.reallyDeleteAccount",
         callback: () => {
           window.scrollTo(0, 0);

--- a/src/app/user/Profile/Stripe.vue
+++ b/src/app/user/Profile/Stripe.vue
@@ -35,14 +35,14 @@ import { doc, onSnapshot, Unsubscribe } from "firebase/firestore";
 import { stripeDeleteCard } from "@/lib/firebase/functions";
 import { useUserData } from "@/utils/utils";
 
-import { useStore } from "vuex";
 import { useGeneralStore } from "@/store";
+import { useDialogStore } from "@/store/dialog";
 import moment from "moment";
 
 export default defineComponent({
   setup() {
-    const store = useStore();
     const generalStore = useGeneralStore();
+    const dialogStore = useDialogStore();
     const { isLiffUser, user } = useUserData();
 
     const storedCard = ref<{ brand: string; last4: string } | null>(null);
@@ -85,7 +85,7 @@ export default defineComponent({
     };
 
     const handleDeleteCard = () => {
-      store.commit("setAlert", {
+      dialogStore.setAlert({
         code: "profile.reallyDeleteCard",
         callback: async () => {
           console.log("handleDeleteCard");

--- a/src/app/user/Restaurant/LunchDinner.vue
+++ b/src/app/user/Restaurant/LunchDinner.vue
@@ -41,7 +41,7 @@
 
 <script lang="ts">
 import { defineComponent, ref } from "vue";
-import { useStore } from "vuex";
+import { useDialogStore } from "@/store/dialog";
 
 export default defineComponent({
   props: {
@@ -60,7 +60,7 @@ export default defineComponent({
   },
   emits: ["update:modelValue"],
   setup(props, ctx) {
-    const store = useStore();
+    const dialogStore = useDialogStore();
     const popup = ref(false);
 
     const input = (value: string) => {
@@ -68,7 +68,7 @@ export default defineComponent({
         (value === "dinner" && props.hasLunchOnlyOrder) ||
         (value === "lunch" && props.hasDinnerOnlyOrder)
       ) {
-        store.commit("setAlert", {
+        dialogStore.setAlert({
           title: "lunchOrDinner.alert." + value + ".title",
           code: "lunchOrDinner.alert." + value + ".body",
           callback: () => {


### PR DESCRIPTION
## Summary
- use Pinia dialog store for alerts across admin/user components
- remove unused Vuex store imports after migration

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689af7d5d8b8833381394a28ae62075e