### PR TITLE
chore: remove dark mode classes

### DIFF
--- a/src/app/admin/AllOrders.vue
+++ b/src/app/admin/AllOrders.vue
@@ -23,7 +23,7 @@
       <div class="mx-6 mt-4">
         <select
           v-model="orderState"
-          class="mt-1 rounded-lg border border-teal-400 bg-white px-3 py-2 hover:border-teal-400 focus:ring-teal-400 dark:border-gray-600 dark:bg-black dark:text-white"
+          class="mt-1 rounded-lg border border-teal-400 bg-white px-3 py-2 hover:border-teal-400 focus:ring-teal-400"
         >
           <option
             v-for="status in orderStatus"

--- a/src/app/admin/Notifications/NotificationSettings.vue
+++ b/src/app/admin/Notifications/NotificationSettings.vue
@@ -113,7 +113,7 @@
             <div class="mt-2 flex items-center">
               <select
                 v-model="soundIndex"
-                class="mt-1 mt-2 mr-2 rounded-lg border border-teal-400 bg-white px-3 py-2 hover:border-teal-400 focus:ring-teal-400 dark:border-gray-600 dark:bg-black dark:text-white"
+                class="mt-1 mt-2 mr-2 rounded-lg border border-teal-400 bg-white px-3 py-2 hover:border-teal-400 focus:ring-teal-400"
               >
                 <option
                   v-for="(soundFile, index) in soundFiles"

--- a/src/app/admin/Restaurants/Delivery.vue
+++ b/src/app/admin/Restaurants/Delivery.vue
@@ -99,7 +99,7 @@
               </span>
               <span class="flex-item mt-auto mr-2 mb-auto inline-block">
                 <input
-                  class="rounded-lg border border-black/20 bg-white px-4 py-1 dark:bg-black dark:text-gray-200"
+                  class="rounded-lg border border-black/20 bg-white px-4 py-1"
                   v-model="radius"
                   :disabled="!enableAreaMap || !enableDelivery"
                 />
@@ -130,7 +130,7 @@
               v-model="areaText"
               :placeholder="$t('delivery.areaTextExample')"
               :disabled="!enableAreaText || !enableDelivery"
-              class="resize-vertical w-full rounded-lg border border-gray-300 px-3 py-2 dark:bg-black dark:text-gray-200"
+              class="resize-vertical w-full rounded-lg border border-gray-300 px-3 py-2"
               rows="4"
             >
             </textarea>
@@ -149,7 +149,7 @@
             />
             <span class="flex-item mt-auto mr-2 mb-auto inline-block">
               <input
-                class="rounded-lg border border-black/20 bg-white px-4 py-1 dark:bg-black dark:text-gray-200"
+                class="rounded-lg border border-black/20 bg-white px-4 py-1"
                 v-model="deliveryThreshold"
                 :disabled="!enableDelivery"
                 type="number"
@@ -172,7 +172,7 @@
             </span>
             <span class="flex-item mt-auto mr-2 mb-auto inline-block">
               <input
-                class="rounded-lg border border-black/20 bg-white px-4 py-1 dark:bg-black dark:text-gray-200"
+                class="rounded-lg border border-black/20 bg-white px-4 py-1"
                 v-model="deliveryFee"
                 :disabled="!enableDelivery"
                 type="number"
@@ -194,7 +194,7 @@
             </span>
             <span class="flex-item mt-auto mr-2 mb-auto inline-block">
               <input
-                class="rounded-lg border border-black/20 bg-white px-4 py-1 dark:bg-black dark:text-gray-200"
+                class="rounded-lg border border-black/20 bg-white px-4 py-1"
                 v-model="deliveryFreeThreshold"
                 :disabled="!enableDelivery"
                 type="number"
@@ -220,7 +220,7 @@
           <div>
             {{ $t("editRestaurant.deliveryPreparationTime") }}
             <input
-              class="rounded-lg border border-black/20 bg-white px-4 py-1 dark:bg-black dark:text-gray-200"
+              class="rounded-lg border border-black/20 bg-white px-4 py-1"
               v-model="deliveryMinimumCookTime"
               :disabled="!enableDelivery"
               type="number"

--- a/src/app/admin/Restaurants/Discount/Discount.vue
+++ b/src/app/admin/Restaurants/Discount/Discount.vue
@@ -47,7 +47,7 @@
           <input
             type="text"
             v-model="promotion.promotionName"
-            class="w-full rounded-lg border border-gray-300 bg-white px-3 py-2 dark:bg-black dark:text-gray-200"
+            class="w-full rounded-lg border border-gray-300 bg-white px-3 py-2"
           />
         </div>
       </div>
@@ -57,7 +57,7 @@
         </div>
         <select
           v-model="promotion.enable"
-          class="rounded-lg border border-teal-400 bg-white px-3 py-2 hover:border-teal-400 focus:ring-teal-400 dark:border-gray-600 dark:bg-black dark:text-white"
+          class="rounded-lg border border-teal-400 bg-white px-3 py-2 hover:border-teal-400 focus:ring-teal-400"
         >
           <option
             v-for="(result, key) in toBeOrNotSelect"
@@ -74,7 +74,7 @@
         </div>
         <select
           v-model="promotion.type"
-          class="rounded-lg border border-teal-400 bg-white px-3 py-2 hover:border-teal-400 focus:ring-teal-400 dark:border-gray-600 dark:bg-black dark:text-white"
+          class="rounded-lg border border-teal-400 bg-white px-3 py-2 hover:border-teal-400 focus:ring-teal-400"
         >
           <option
             v-for="(result, key) in discountTypeSelect"
@@ -92,7 +92,7 @@
 
         <select
           v-model="promotion.hasTerm"
-          class="rounded-lg border border-teal-400 bg-white px-3 py-2 hover:border-teal-400 focus:ring-teal-400 dark:border-gray-600 dark:bg-black dark:text-white"
+          class="rounded-lg border border-teal-400 bg-white px-3 py-2 hover:border-teal-400 focus:ring-teal-400"
         >
           <option
             v-for="(result, key) in toBeOrNotSelect"
@@ -130,7 +130,7 @@
               v-model="promotion.discountThreshold"
               :step="1"
               min="0"
-              class="rounded-lg border border-gray-300 bg-white px-3 py-2 dark:bg-black dark:text-gray-200"
+              class="rounded-lg border border-gray-300 bg-white px-3 py-2"
             />
             <span class="button is-static">
               {{ $t("currency.JPY") }}
@@ -144,7 +144,7 @@
         </div>
         <select
           v-model="promotion.usageRestrictions"
-          class="rounded-lg border border-teal-400 bg-white px-3 py-2 hover:border-teal-400 focus:ring-teal-400 dark:border-gray-600 dark:bg-black dark:text-white"
+          class="rounded-lg border border-teal-400 bg-white px-3 py-2 hover:border-teal-400 focus:ring-teal-400"
         >
           <option
             v-for="(result, key) in toBeOrNotSelect2"
@@ -161,7 +161,7 @@
         </div>
         <select
           v-model="promotion.discountMethod"
-          class="rounded-lg border border-teal-400 bg-white px-3 py-2 hover:border-teal-400 focus:ring-teal-400 dark:border-gray-600 dark:bg-black dark:text-white"
+          class="rounded-lg border border-teal-400 bg-white px-3 py-2 hover:border-teal-400 focus:ring-teal-400"
         >
           <option
             v-for="(result, key) in discountMethodSelect"
@@ -188,7 +188,7 @@
             min="0"
             inputmode="decimal"
             v-model="promotion.discountValue"
-            class="rounded-l-lg border border-gray-300 bg-white px-3 py-2 dark:bg-black dark:text-gray-200"
+            class="rounded-l-lg border border-gray-300 bg-white px-3 py-2"
           />
           <span class="button is-static">
             <template v-if="promotion.discountMethod === 'amount'">
@@ -204,7 +204,7 @@
         </div>
         <select
           v-model="promotion.paymentRestrictions"
-          class="rounded-lg border border-teal-400 bg-white px-3 py-2 hover:border-teal-400 focus:ring-teal-400 dark:border-gray-600 dark:bg-black dark:text-white"
+          class="rounded-lg border border-teal-400 bg-white px-3 py-2 hover:border-teal-400 focus:ring-teal-400"
         >
           <option
             v-for="(result, key) in promotionPaymentRestrictionsSelect"

--- a/src/app/admin/Restaurants/Index.vue
+++ b/src/app/admin/Restaurants/Index.vue
@@ -532,7 +532,7 @@
                     v-model.number="editShopInfo.pickUpMinimumCookTime"
                     placeholder="10"
                     type="text"
-                    class="w-24 rounded-lg border border-gray-300 bg-white px-3 py-2 dark:bg-black dark:text-gray-200"
+                    class="w-24 rounded-lg border border-gray-300 bg-white px-3 py-2"
                     :class="
                       errors['pickUpMinimumCookTime'].length > 0
                         ? 'border-red-500'
@@ -554,7 +554,7 @@
                   >
                     <label class="mr-2 inline-flex cursor-pointer items-center">
                       <input
-                        class="m-auto mt-1 mr-1 h-4 w-4 cursor-pointer appearance-none rounded-full border border-teal-400 bg-white checked:border-teal-400 checked:bg-teal-400 hover:border-teal-400 focus:ring-teal-400 dark:border-gray-600 dark:bg-black dark:text-white"
+                        class="m-auto mt-1 mr-1 h-4 w-4 cursor-pointer appearance-none rounded-full border border-teal-400 bg-white checked:border-teal-400 checked:bg-teal-400 hover:border-teal-400 focus:ring-teal-400"
                         type="radio"
                         v-model="editShopInfo.pickUpMinimumCookTime"
                         :value="choice.value"
@@ -576,7 +576,7 @@
                 </div>
                 <select
                   v-model.number="editShopInfo.pickUpDaysInAdvance"
-                  class="mt-1 rounded-lg border border-teal-400 bg-white px-3 py-2 hover:border-teal-400 focus:ring-teal-400 dark:border-gray-600 dark:bg-black dark:text-white"
+                  class="mt-1 rounded-lg border border-teal-400 bg-white px-3 py-2 hover:border-teal-400 focus:ring-teal-400"
                 >
                   <option
                     v-for="(day, index) in reservationTheDayBefore"
@@ -603,7 +603,7 @@
                 <label class="mr-2 inline-flex cursor-pointer items-center">
                   <input
                     type="radio"
-                    class="m-auto mt-1 mr-1 h-4 w-4 cursor-pointer appearance-none rounded-full border border-teal-400 bg-white checked:border-teal-400 checked:bg-teal-400 hover:border-teal-400 focus:ring-teal-400 dark:border-gray-600 dark:bg-black dark:text-white"
+                    class="m-auto mt-1 mr-1 h-4 w-4 cursor-pointer appearance-none rounded-full border border-teal-400 bg-white checked:border-teal-400 checked:bg-teal-400 hover:border-teal-400 focus:ring-teal-400"
                     v-model="editShopInfo.personalInfo"
                     :value="personalInfoSaveMethod.key"
                   />

--- a/src/app/admin/Restaurants/Line/Index.vue
+++ b/src/app/admin/Restaurants/Line/Index.vue
@@ -49,7 +49,7 @@
           <input
             type="text"
             v-model="clientId"
-            class="w-full rounded-lg border border-gray-300 bg-gray-100 px-3 py-2 dark:border-gray-600 dark:bg-black dark:text-white"
+            class="w-full rounded-lg border border-gray-300 bg-gray-100 px-3 py-2"
           />
         </div>
 
@@ -68,7 +68,7 @@
           <input
             type="text"
             v-model="client_secret"
-            class="w-full rounded-lg border border-gray-300 bg-gray-100 px-3 py-2 dark:border-gray-600 dark:bg-black dark:text-white"
+            class="w-full rounded-lg border border-gray-300 bg-gray-100 px-3 py-2"
           />
         </div>
 
@@ -87,7 +87,7 @@
           <input
             type="text"
             v-model="message_token"
-            class="w-full rounded-lg border border-gray-300 bg-gray-100 px-3 py-2 dark:border-gray-600 dark:bg-black dark:text-white"
+            class="w-full rounded-lg border border-gray-300 bg-gray-100 px-3 py-2"
           />
         </div>
 
@@ -110,7 +110,7 @@
             type="text"
             :value="callbackUrl"
             readonly
-            class="w-full rounded-lg border border-gray-300 bg-gray-100 px-3 py-2 dark:border-gray-600 dark:bg-black dark:text-white"
+            class="w-full rounded-lg border border-gray-300 bg-gray-100 px-3 py-2"
           />
         </div>
 

--- a/src/app/admin/Restaurants/MenuItemPage.vue
+++ b/src/app/admin/Restaurants/MenuItemPage.vue
@@ -91,7 +91,7 @@
               <input
                 v-model="menuInfo.itemName"
                 :placeholder="$t('editMenu.enterItemName')"
-                class="w-full rounded-lg border border-gray-300 bg-white px-3 py-2 dark:border-gray-600 dark:bg-black dark:text-white"
+                class="w-full rounded-lg border border-gray-300 bg-white px-3 py-2"
                 :class="
                   errors['itemName'].length > 0
                     ? 'border-red-500'
@@ -109,7 +109,7 @@
             <input
               v-model="menuInfo.itemAliasesName"
               :placeholder="$t('editMenu.enterItemAliasesName')"
-              class="w-full rounded-lg border border-gray-300 bg-white px-3 py-2 dark:border-gray-600 dark:bg-black dark:text-white"
+              class="w-full rounded-lg border border-gray-300 bg-white px-3 py-2"
             />
           </div>
 
@@ -130,7 +130,7 @@
                     placeholder="00.00"
                     :max="maxPrice"
                     min="0.00"
-                    class="flex-1 rounded-l-lg border border-gray-300 px-3 py-2 dark:bg-black dark:text-gray-200"
+                    class="flex-1 rounded-l-lg border border-gray-300 px-3 py-2"
                     :class="
                       errors['price'].length > 0
                         ? 'border-red-500'
@@ -155,7 +155,7 @@
               <div>
                 <select
                   v-model="menuInfo.tax"
-                  class="w-full rounded-lg border border-teal-400 bg-white px-3 py-2 hover:border-teal-400 focus:ring-teal-400 dark:border-gray-600 dark:bg-black dark:text-white"
+                  class="w-full rounded-lg border border-teal-400 bg-white px-3 py-2 hover:border-teal-400 focus:ring-teal-400"
                 >
                   <option
                     v-for="taxItem in taxRates"
@@ -207,7 +207,7 @@
                 <textarea
                   v-model="menuInfo.itemDescription"
                   :placeholder="$t('editMenu.enterItemDescription')"
-                  class="resize-vertical w-full rounded-lg border border-gray-300 px-3 py-2 dark:bg-black dark:text-gray-200"
+                  class="resize-vertical w-full rounded-lg border border-gray-300 px-3 py-2"
                   :class="
                     errors['itemDescription'].length > 0
                       ? 'border-red-500'
@@ -229,7 +229,7 @@
                 <textarea
                   v-model="menuInfo.itemMemo"
                   :placeholder="$t('editMenu.enterItemMemo')"
-                  class="resize-vertical w-full rounded border border-green-500 px-3 py-2 dark:bg-black dark:text-gray-200"
+                  class="resize-vertical w-full rounded border border-green-500 px-3 py-2"
                   rows="4"
                 ></textarea>
               </div>
@@ -444,7 +444,7 @@
                     <input
                       v-model="menuInfo.itemOptionCheckbox[key]"
                       :placeholder="$t('editMenu.enterItemOption')"
-                      class="w-full rounded-lg border border-gray-300 bg-white px-3 py-2 dark:border-gray-600 dark:bg-black dark:text-white"
+                      class="w-full rounded-lg border border-gray-300 bg-white px-3 py-2"
                     />
                   </div>
                   <button class="cursor-pointer" @click="deleteOption(key)">
@@ -550,7 +550,7 @@
                 <select
                   v-if="categories1.length > 0"
                   v-model="menuInfo.category1"
-                  class="mt-1 mt-2 w-full rounded-lg border border-teal-400 bg-white px-3 py-2 hover:border-teal-400 focus:ring-teal-400 dark:border-gray-600 dark:bg-black dark:text-white"
+                  class="mt-1 mt-2 w-full rounded-lg border border-teal-400 bg-white px-3 py-2 hover:border-teal-400 focus:ring-teal-400"
                 >
                   <option
                     v-for="category in categories1"
@@ -585,7 +585,7 @@
                 <select
                   v-if="categories2.length > 0"
                   v-model="menuInfo.category2"
-                  class="mt-1 mt-2 w-full rounded-lg border border-teal-400 bg-white px-3 py-2 hover:border-teal-400 focus:ring-teal-400 dark:border-gray-600 dark:bg-black dark:text-white"
+                  class="mt-1 mt-2 w-full rounded-lg border border-teal-400 bg-white px-3 py-2 hover:border-teal-400 focus:ring-teal-400"
                 >
                   <option
                     v-for="category in categories2"
@@ -686,7 +686,7 @@
         <div class="mt-4">
           <select
             v-model="copyRestaurantId"
-            class="w-full rounded-lg border border-teal-400 bg-white px-3 py-2 hover:border-teal-400 focus:ring-teal-400 dark:border-gray-600 dark:bg-black dark:text-white"
+            class="w-full rounded-lg border border-teal-400 bg-white px-3 py-2 hover:border-teal-400 focus:ring-teal-400"
           >
             <option
               v-for="restaurant in restaurants"

--- a/src/app/admin/Restaurants/MenuItemPage/EditCategory.vue
+++ b/src/app/admin/Restaurants/MenuItemPage/EditCategory.vue
@@ -28,7 +28,7 @@
       <!-- Add Item -->
       <div class="flex">
         <input
-          class="mr-2 w-full flex-1 rounded-lg border border-gray-300 bg-white px-3 py-2 dark:border-gray-600 dark:bg-black dark:text-white"
+          class="mr-2 w-full flex-1 rounded-lg border border-gray-300 bg-white px-3 py-2"
           :placeholder="$t('editMenu.newCategory')"
           v-model="newEntry"
         />

--- a/src/app/admin/Restaurants/OrderHistory.vue
+++ b/src/app/admin/Restaurants/OrderHistory.vue
@@ -21,7 +21,7 @@
           </div>
           <select
             v-model="orderState"
-            class="mt-1 mt-2 rounded-lg border border-teal-400 bg-white px-3 py-2 hover:border-teal-400 focus:ring-teal-400 dark:border-gray-600 dark:bg-black dark:text-white"
+            class="mt-1 mt-2 rounded-lg border border-teal-400 bg-white px-3 py-2 hover:border-teal-400 focus:ring-teal-400"
           >
             <option
               v-for="status in orderStatus"
@@ -43,7 +43,7 @@
           </div>
           <select
             v-model="sortOrder"
-            class="mt-1 rounded-lg border border-teal-400 bg-white px-3 py-2 hover:border-teal-400 focus:ring-teal-400 dark:border-gray-600 dark:bg-black dark:text-white"
+            class="mt-1 rounded-lg border border-teal-400 bg-white px-3 py-2 hover:border-teal-400 focus:ring-teal-400"
           >
             <option
               v-for="status in orderSorts"

--- a/src/app/admin/Restaurants/OrderInfoPage.vue
+++ b/src/app/admin/Restaurants/OrderInfoPage.vue
@@ -192,7 +192,7 @@
               </div>
               <select
                 v-model="timeOffset"
-                class="mt-1 mt-2 rounded-lg border border-teal-400 bg-white px-3 py-2 hover:border-teal-400 focus:ring-teal-400 dark:border-gray-600 dark:bg-black dark:text-white"
+                class="mt-1 mt-2 rounded-lg border border-teal-400 bg-white px-3 py-2 hover:border-teal-400 focus:ring-teal-400"
               >
                 <option
                   v-for="time in estimatedTimes"

--- a/src/app/admin/Restaurants/OrderListPage.vue
+++ b/src/app/admin/Restaurants/OrderListPage.vue
@@ -27,7 +27,7 @@
         <div class="mt-4 ml-6 sm:ml-4">
           <select
             v-model="dayIndex"
-            class="mt-1 rounded-lg border border-teal-400 bg-white px-3 py-2 hover:border-teal-400 focus:ring-teal-400 dark:border-gray-600 dark:bg-black dark:text-white"
+            class="mt-1 rounded-lg border border-teal-400 bg-white px-3 py-2 hover:border-teal-400 focus:ring-teal-400"
           >
             <option
               v-for="day in lastSeveralDays"

--- a/src/app/admin/Restaurants/Postage.vue
+++ b/src/app/admin/Restaurants/Postage.vue
@@ -21,7 +21,7 @@
               <input
                 type="number"
                 inputmode="decimal"
-                class="w-4/12 rounded-lg border border-gray-300 bg-white px-3 py-2 dark:bg-black dark:text-gray-200"
+                class="w-4/12 rounded-lg border border-gray-300 bg-white px-3 py-2"
                 :class="{ 'py-3': key === 0 }"
                 v-model.number="postage[key]"
                 min="0"
@@ -51,13 +51,13 @@
             <input
               type="number"
               inputmode="decimal"
-              class="w-4/12 rounded-lg border border-gray-300 px-3 py-2 dark:text-gray-200"
+              class="w-4/12 rounded-lg border border-gray-300 px-3 py-2"
               v-model.number="freeThreshold"
               :disabled="!enableFree"
               :class="
                 !enableFree
-                  ? 'bg-gray-100 dark:bg-gray-300'
-                  : 'bg-white dark:bg-black'
+                  ? 'bg-gray-100'
+                  : 'bg-white'
               "
               min="0"
             />

--- a/src/app/admin/Restaurants/ReportPage.vue
+++ b/src/app/admin/Restaurants/ReportPage.vue
@@ -34,7 +34,7 @@
       <div class="mx-6 mt-4">
         <select
           v-model="monthIndex"
-          class="mt-1 mt-2 rounded-lg border border-teal-400 bg-white px-3 py-2 hover:border-teal-400 focus:ring-teal-400 dark:border-gray-600 dark:bg-black dark:text-white"
+          class="mt-1 mt-2 rounded-lg border border-teal-400 bg-white px-3 py-2 hover:border-teal-400 focus:ring-teal-400"
         >
           <option
             v-for="day in lastSeveralMonths"

--- a/src/app/admin/Smaregi/Index.vue
+++ b/src/app/admin/Smaregi/Index.vue
@@ -41,7 +41,7 @@
               連携する店舗：
               <select
                 v-model="selectedRestaurant[k]"
-                class="rounded-lg border border-teal-400 bg-white px-3 py-2 hover:border-teal-400 focus:ring-teal-400 dark:border-gray-600 dark:bg-black dark:text-white"
+                class="rounded-lg border border-teal-400 bg-white px-3 py-2 hover:border-teal-400 focus:ring-teal-400"
                 :class="
                   selectedRestaurant[k] &&
                   duplicateElement[selectedRestaurant[k]]
@@ -63,7 +63,7 @@
               在庫切れしきい値:
               <select
                 v-model="outOfStockData[k]"
-                class="rounded-lg border border-teal-400 bg-white px-3 py-2 hover:border-teal-400 focus:ring-teal-400 dark:border-gray-600 dark:bg-black dark:text-white"
+                class="rounded-lg border border-teal-400 bg-white px-3 py-2 hover:border-teal-400 focus:ring-teal-400"
               >
                 <option
                   v-for="threshold in outOfStockThresholds"
@@ -79,7 +79,7 @@
               在庫復活しきい値:
               <select
                 v-model="inStockData[k]"
-                class="rounded-lg border border-teal-400 bg-white px-3 py-2 hover:border-teal-400 focus:ring-teal-400 dark:border-gray-600 dark:bg-black dark:text-white"
+                class="rounded-lg border border-teal-400 bg-white px-3 py-2 hover:border-teal-400 focus:ring-teal-400"
               >
                 <option
                   v-for="threshold in inStockThresholds"

--- a/src/app/admin/Smaregi/Store.vue
+++ b/src/app/admin/Smaregi/Store.vue
@@ -37,7 +37,7 @@
           おもちかえり:
           <select
             v-model="selectedMenu[key]"
-            class="rounded-lg border border-teal-400 bg-white px-3 py-2 hover:border-teal-400 focus:ring-teal-400 dark:border-gray-600 dark:bg-black dark:text-white"
+            class="rounded-lg border border-teal-400 bg-white px-3 py-2 hover:border-teal-400 focus:ring-teal-400"
             :class="
               selectedMenu[key] && duplicateElement[selectedMenu[key]]
                 ? 'border-2 border-solid border-red-700'

--- a/src/app/admin/inputComponents/HourInput2.vue
+++ b/src/app/admin/inputComponents/HourInput2.vue
@@ -5,7 +5,7 @@
         :value="modelValue"
         :disabled="disabled"
         @change="updateValue"
-        class="rounded-lg border-2 bg-white px-3 py-2 dark:border-gray-600 dark:bg-black dark:text-white"
+        class="rounded-lg border-2 bg-white px-3 py-2"
         :class="
           variant === 'danger'
             ? 'border-red-400 hover:border-red-400 focus:ring-red-400'

--- a/src/app/admin/inputComponents/HoursInput.vue
+++ b/src/app/admin/inputComponents/HoursInput.vue
@@ -5,7 +5,7 @@
         :value="modelValue.start"
         :disabled="disabled"
         @change="updateValueStart"
-        class="rounded-lg border-2 bg-white px-3 py-2 dark:border-gray-600 dark:bg-black dark:text-white"
+        class="rounded-lg border-2 bg-white px-3 py-2"
         :class="
           variant === 'danger'
             ? 'border-red-400 hover:border-red-400 focus:ring-red-400'
@@ -29,7 +29,7 @@
         :value="modelValue.end"
         :disabled="disabled"
         @change="updateValueEnd"
-        class="rounded-lg border-2 bg-white px-3 py-2 dark:border-gray-600 dark:bg-black dark:text-white"
+        class="rounded-lg border-2 bg-white px-3 py-2"
         :class="
           variant === 'danger'
             ? 'border-red-400 hover:border-red-400 focus:ring-red-400'

--- a/src/app/admin/inputComponents/State.vue
+++ b/src/app/admin/inputComponents/State.vue
@@ -8,7 +8,7 @@
       :modelValue="modelValue"
       placeholder="select"
       @update:modelValue="input"
-      class="rounded-lg border border-teal-400 bg-white px-3 py-2 hover:border-teal-400 focus:ring-teal-400 dark:border-gray-600 dark:bg-black dark:text-white"
+      class="rounded-lg border border-teal-400 bg-white px-3 py-2 hover:border-teal-400 focus:ring-teal-400"
     >
       <option v-for="stateItem in states" :key="stateItem">
         {{ stateItem }}

--- a/src/app/super/AllOrders.vue
+++ b/src/app/super/AllOrders.vue
@@ -10,7 +10,7 @@
           <h2>All Orders</h2>
           <select
             v-model="orderState"
-            class="mt-4 rounded-lg border border-teal-400 bg-white px-3 py-2 hover:border-teal-400 focus:ring-teal-400 dark:border-gray-600 dark:bg-black dark:text-white"
+            class="mt-4 rounded-lg border border-teal-400 bg-white px-3 py-2 hover:border-teal-400 focus:ring-teal-400"
           >
             <option
               v-for="status in orderStatus"
@@ -26,7 +26,7 @@
               <div class="flex">
                 <select
                   v-model="monthValue"
-                  class="mt-1 rounded-lg border border-teal-400 bg-white px-3 py-2 hover:border-teal-400 focus:ring-teal-400 dark:border-gray-600 dark:bg-black dark:text-white"
+                  class="mt-1 rounded-lg border border-teal-400 bg-white px-3 py-2 hover:border-teal-400 focus:ring-teal-400"
                 >
                   <option v-for="(month, k) in months" :value="month" :key="k">
                     {{ month }}

--- a/src/app/user/OrderPage/BeforePaid/ECCustomer.vue
+++ b/src/app/user/OrderPage/BeforePaid/ECCustomer.vue
@@ -62,7 +62,7 @@
     <select
       :value="customerInfo.prefectureId"
       @change="updatePrefecture"
-      class="rounded-lg border-2 bg-white px-3 py-2 dark:border-gray-600 dark:bg-black dark:text-white"
+      class="rounded-lg border-2 bg-white px-3 py-2"
       :class="
         ecErrors['prefectureId'].length > 0
           ? 'border-red-400 hover:border-red-400 focus:ring-red-400'

--- a/src/app/user/OrderPage/BeforePaid/TimeToPickup.vue
+++ b/src/app/user/OrderPage/BeforePaid/TimeToPickup.vue
@@ -5,7 +5,7 @@
       <div class="flex flex-wrap gap-2 rounded-lg bg-white p-4 shadow-sm">
         <select
           v-model="dayIndex"
-          class="rounded-lg border border-teal-400 bg-white px-3 py-2 hover:border-teal-400 focus:ring-teal-400 dark:border-gray-600 dark:bg-black dark:text-white"
+          class="rounded-lg border border-teal-400 bg-white px-3 py-2 hover:border-teal-400 focus:ring-teal-400"
         >
           <option
             v-for="(day, index) in availableDays"
@@ -18,7 +18,7 @@
         </select>
         <select
           v-model="time"
-          class="rounded-lg border border-teal-400 bg-white px-3 py-2 hover:border-teal-400 focus:ring-teal-400 dark:border-gray-600 dark:bg-black dark:text-white"
+          class="rounded-lg border border-teal-400 bg-white px-3 py-2 hover:border-teal-400 focus:ring-teal-400"
         >
           <option
             v-for="(time, index) in availableDays[dayIndex].times"

--- a/src/components/DatePicker.vue
+++ b/src/components/DatePicker.vue
@@ -5,7 +5,7 @@
       :value="formattedDate"
       @click="openCalendar"
       readonly
-      class="w-full cursor-pointer rounded border border-gray-300 p-2 dark:border-gray-600 dark:bg-black dark:text-white"
+      class="w-full cursor-pointer rounded border border-gray-300 p-2"
       :placeholder="placeholder"
     />
     <div

--- a/src/components/DateTimePicker.vue
+++ b/src/components/DateTimePicker.vue
@@ -5,7 +5,7 @@
       :value="formattedDate"
       @click="openCalendar"
       readonly
-      class="cursor-pointer rounded border border-gray-300 p-2 dark:border-gray-600 dark:bg-black dark:text-white"
+      class="cursor-pointer rounded border border-gray-300 p-2"
       :placeholder="placeholder"
     />
     <div
@@ -56,7 +56,7 @@
             v-model="hours"
             min="0"
             max="23"
-            class="w-16 rounded border border-gray-300 p-1 text-center dark:border-gray-600 dark:bg-black dark:text-white"
+            class="w-16 rounded border border-gray-300 p-1 text-center"
           />
           <span>:</span>
           <input
@@ -64,7 +64,7 @@
             v-model="minutes"
             min="0"
             max="59"
-            class="w-16 rounded border border-gray-300 p-1 text-center dark:border-gray-600 dark:bg-black dark:text-white"
+            class="w-16 rounded border border-gray-300 p-1 text-center"
           />
         </div>
         <div class="mt-4 flex justify-center">

--- a/src/components/Loading.vue
+++ b/src/components/Loading.vue
@@ -6,7 +6,7 @@
     >
       <svg
         aria-hidden="true"
-        class="fill-op-teal/80 h-20 w-20 animate-spin text-gray-200 dark:text-gray-600"
+        class="fill-op-teal/80 h-20 w-20 animate-spin text-gray-200"
         viewBox="0 0 100 101"
         fill="none"
         xmlns="http://www.w3.org/2000/svg"

--- a/src/components/form/Loading.vue
+++ b/src/components/form/Loading.vue
@@ -1,7 +1,7 @@
 <template>
   <span class="absolute opacity-30">
     <svg
-      class="w-8 animate-spin fill-blue-600 text-gray-200 dark:text-gray-600"
+      class="w-8 animate-spin fill-blue-600 text-gray-200"
       viewBox="0 0 100 101"
       xmlns="http://www.w3.org/2000/svg"
     >


### PR DESCRIPTION
## Summary
- remove Tailwind `dark:` classes to disable dark mode styling

## Testing
- `npx eslint src`


------
https://chatgpt.com/codex/tasks/task_e_689e3ac9d9308333829ff4799bd0351b