### PR TITLE
fix: PR #1626 の CodeRabbit 指摘対応

### DIFF
--- a/src/app/admin/Restaurants/Index.vue
+++ b/src/app/admin/Restaurants/Index.vue
@@ -1189,9 +1189,12 @@ export default defineComponent({
     // external ref
     const submitting = ref(false);
     const newTemporaryClosure = ref<Date | null>(null);
-    const searchResults = ref<
-      { place_id: string; geometry: google.maps.places.PlaceGeometry }[]
-    >([]);
+    type GeocodeResult = {
+      place_id: string;
+      formatted_address: string;
+      geometry: { location: { lat: number; lng: number } };
+    };
+    const searchResults = ref<GeocodeResult[]>([]);
     const selectedResult = ref(0);
 
     const editShopInfo = reactive(props.shopInfo);

--- a/src/app/user/OrderPage/BeforePaid/StripeCard.vue
+++ b/src/app/user/OrderPage/BeforePaid/StripeCard.vue
@@ -112,7 +112,6 @@
 import { defineComponent, ref, watch, onMounted, computed } from "vue";
 
 import { getStripeInstance } from "@/lib/stripe/stripe";
-import type { StripePaymentElement, StripePaymentElementChangeEvent } from "@stripe/stripe-js";
 import { db } from "@/lib/firebase/firebase9";
 import { doc, getDoc } from "firebase/firestore";
 import moment from "moment";
@@ -158,7 +157,9 @@ export default defineComponent({
   },
   setup(props, ctx) {
     const stripe = getStripeInstance(props.stripeAccount);
-    const cardElem = ref<StripePaymentElement | null>(null);
+    // Stripe is loaded via script tag (window.Stripe), so no dedicated types are available.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const cardElem = ref<any>(null);
     let elementStatus = { complete: false };
 
     const storedCard = ref(null);
@@ -174,7 +175,7 @@ export default defineComponent({
       cardElem.value = cardElement;
       cardElem.value.addEventListener(
         "change",
-        (status: StripePaymentElementChangeEvent) => {
+        (status: { complete: boolean }) => {
           elementStatus = status;
           if (!useStoredCard.value) {
             ctx.emit("change", status);

--- a/src/app/user/RestaurantPage.vue
+++ b/src/app/user/RestaurantPage.vue
@@ -627,7 +627,7 @@ export default defineComponent({
     };
     const updateSelectedOptions = (
       id: string,
-      e: (number | boolean)[][],
+      e: (boolean | string)[][],
     ) => {
       const newSelectedOptions = Object.assign({}, selectedOptions.value);
       newSelectedOptions[id] = e;

--- a/src/lib/firebase/functions.ts
+++ b/src/lib/firebase/functions.ts
@@ -26,7 +26,12 @@ export const smaregiStoreList = httpsCallable<
 export const smaregiProductList = httpsCallable<
   SmaregiProductListData,
   {
-    res: { productId: string; productName: string; price: number }[];
+    res: {
+      productId: string;
+      productCode: string;
+      productName: string;
+      price: number;
+    }[];
   }
 >(functionsJP, "smaregiProductList2");
 

--- a/src/models/cartType.ts
+++ b/src/models/cartType.ts
@@ -4,10 +4,8 @@ export type OrderDataType = {
 
 import { MenuData } from "./menu";
 
-export type CartItemsType = {
-  [key: string]: MenuData;
-};
+export type CartItemsType = Partial<Record<string, MenuData>>;
 
 export type CartOptionType = {
-  [key: string]: (number | boolean)[][];
+  [key: string]: (boolean | string)[][];
 };

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -526,7 +526,7 @@ export const getPrices = (
   return ret;
 };
 
-type SelectedOption = (number | boolean)[];
+type SelectedOption = (boolean | string)[];
 
 export const getTrimmedSelectedOptions = (
   orders: { [key: string]: number[] },


### PR DESCRIPTION
## Summary
PR #1626 に対する CodeRabbit のレビューコメント 5 件に対応。**全て型定義のみの変更で、runtime の挙動は一切変わりません**。

## 修正内容

### 1. \`searchResults\` の型を Google Geocoding REST API の応答形式に修正
**ファイル**: \`src/app/admin/Restaurants/Index.vue\`

\`google.maps.places.PlaceGeometry\` は JS library の型で、REST API の返り値（\`formatted_address\` / \`geometry.location: { lat, lng }\`）とは形状が違うため、\`GeocodeResult\` 型を新規定義。
テンプレートで \`result.formatted_address\` を参照している箇所（Line 173）もこれで型チェックされるようになる。

### 2. \`updateSelectedOptions\` の型を Menu.vue の emit に合わせる
**ファイル**: \`src/app/user/RestaurantPage.vue\`, \`src/models/cartType.ts\`, \`src/utils/utils.ts\`

Menu.vue (Line 647-655) は \`boolean | string\` 値を emit しているが、前回 PR で \`(number | boolean)[][]\` としていた。以下3箇所を統一的に修正：
- \`RestaurantPage.vue\` の \`updateSelectedOptions\` 引数
- \`CartOptionType\` の値型（単一の真実）
- \`utils.ts\` の \`SelectedOption\` 型

### 3. \`CartItemsType\` を sparse 対応に
**ファイル**: \`src/models/cartType.ts\`

\`{ [key: string]: MenuData }\` だとキーが必ず存在することになるが、消費側（\`utils.ts\` 内 \`cartItems[id] || {}\`）は undefined を前提に guard しているため、\`Partial<Record<string, MenuData>>\` に変更。

### 4. \`smaregiProductList\` の応答型に \`productCode\` を追加
**ファイル**: \`src/lib/firebase/functions.ts\`

\`Smaregi/Store.vue\` (Line 34, 70) で \`product.productCode\` を参照しているが前回 PR で欠落していた。

### 5. \`StripeCard.vue\` の Stripe 型インポート削除
**ファイル**: \`src/app/user/OrderPage/BeforePaid/StripeCard.vue\`

調査したところ \`@stripe/stripe-js\` は package.json / yarn.lock / node_modules いずれにも存在せず、Stripe は index.html の script タグで読み込まれている。前回 PR で追加した \`import type\` は module 不在で silently any にフォールバックしていたため、明示的に \`any\` + \`eslint-disable-next-line\` に戻した。

**CodeRabbit が指摘していた \`addEventListener\` → \`.on()\` の件は実装の変更になるため、別 PR #1628 で対応。**

## Test plan
型の修正のみで runtime の挙動は変わらないため、動作テスト不要。

- [x] \`yarn lint\` 通過
- [x] \`yarn build\` 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)