### PR TITLE
fix: Stripe Element の addEventListener を .on() に変更

### DIFF
--- a/src/app/user/OrderPage/BeforePaid/StripeCard.vue
+++ b/src/app/user/OrderPage/BeforePaid/StripeCard.vue
@@ -173,15 +173,12 @@ export default defineComponent({
       const cardElement = elements.create("payment", {});
       cardElement.mount("#card-element");
       cardElem.value = cardElement;
-      cardElem.value.addEventListener(
-        "change",
-        (status: { complete: boolean }) => {
-          elementStatus = status;
-          if (!useStoredCard.value) {
-            ctx.emit("change", status);
-          }
-        },
-      );
+      cardElem.value.on("change", (status: { complete: boolean }) => {
+        elementStatus = status;
+        if (!useStoredCard.value) {
+          ctx.emit("change", status);
+        }
+      });
 
       try {
         const stripeInfo = (


### PR DESCRIPTION
## Summary
Stripe.js v3 の Element API では change イベントの購読に \`.on()\` メソッドを使う仕様で、\`addEventListener\` はサポートされていません。

既存実装 \`cardElem.value.addEventListener("change", handler)\` は型が \`any\` のため silently 通っていましたが、**runtime 上は change イベントのハンドラが呼ばれず、カード入力の complete 状態が正しく反映されていなかった可能性があります**。

CodeRabbit の PR #1626 レビューでの指摘に基づく修正です。

## 変更内容
\`src/app/user/OrderPage/BeforePaid/StripeCard.vue\`:

\`\`\`diff
-      cardElem.value.addEventListener(
-        "change",
-        (status: { complete: boolean }) => {
-          elementStatus = status;
-          if (!useStoredCard.value) {
-            ctx.emit("change", status);
-          }
-        },
-      );
+      cardElem.value.on("change", (status: { complete: boolean }) => {
+        elementStatus = status;
+        if (!useStoredCard.value) {
+          ctx.emit("change", status);
+        }
+      });
\`\`\`

## ベースブランチ
**PR #1627 (\`fix-coderabbit-review-1626\`) を base にしています。** 先に #1627 をマージしてから、このPRを main にマージするか、差分を取り直してください。

## Test plan（実機での確認必須）
カード決済フロー全般に影響する変更のため、以下の動作確認が必要です：

- [ ] ユーザ画面でカード支払いページに遷移
- [ ] カード情報の入力欄（Stripe Element）が表示される
- [ ] カード情報を入力し、複数フィールドを完了すると「支払う」ボタンが有効になる（これが以前壊れていた可能性のある挙動）
- [ ] 不完全な状態ではボタンが無効のまま
- [ ] 実際にテストカードで決済が成功する
- [ ] 保存済みカードを使う場合は従来通りの挙動であること

🤖 Generated with [Claude Code](https://claude.com/claude-code)