### PR TITLE
refactor: functions/ の any を除去

### DIFF
--- a/functions/src/functions/image/imageUtil.ts
+++ b/functions/src/functions/image/imageUtil.ts
@@ -74,10 +74,10 @@ export const validImagePath = (filePath: string, matchPaths: Array<{ path: strin
         if (match === false) {
           return false;
         }
-        if (splitMatchPath[key as any] === "*") {
+        if (splitMatchPath[Number(key)] === "*") {
           return true;
         }
-        return filePaths[Number(key)] === splitMatchPath[key as any];
+        return filePaths[Number(key)] === splitMatchPath[Number(key)];
       }, true) &&
         filePaths.length === splitMatchPath.length)
     );

--- a/functions/src/functions/order/orderUpdate.ts
+++ b/functions/src/functions/order/orderUpdate.ts
@@ -134,7 +134,10 @@ export const update = async (db: admin.firestore.Firestore, data: OrderUpdateDat
         updateData.timePickupForQuery = updateData.timeEstimated;
         order.timeEstimated = updateData.timeEstimated;
       }
-      await transaction.update(orderRef, updateData as any);
+      await transaction.update(
+        orderRef,
+        updateData as admin.firestore.UpdateData<OrderData>,
+      );
       if (isStripeProcess) {
         const typedPaymentIntent = paymentIntent as StripePaymentIntentWithCharge;
         if (!typedPaymentIntent.latest_charge) {

--- a/functions/src/lib/validator.ts
+++ b/functions/src/lib/validator.ts
@@ -153,19 +153,29 @@ const validateArray = {
   newOrder: validateNewOrder,
 };
 
-const validateData = (data: Record<string, any>, validator: Record<string, any>) => {
+type ValidatorRule = {
+  type?: string;
+  required?: boolean;
+  regex?: RegExp;
+};
+
+const validateData = (
+  data: object,
+  validator: Record<string, ValidatorRule>,
+) => {
+  const record = data as Record<string, unknown>;
   const errors = Object.keys(validator).reduce((tmp: unknown[], key: string) => {
     const rule = validator[key];
-    if (rule.required && isEmpty(data[key])) {
+    if (rule.required && isEmpty(record[key])) {
       tmp.push({
         key,
         empty: true,
       });
       return tmp;
     }
-    if (!isEmpty(data[key])) {
+    if (!isEmpty(record[key])) {
       const validator = validateArray[rule.type as keyof typeof validateArray];
-      if (validator && !validator(data[key] as never)) {
+      if (validator && !validator(record[key] as never)) {
         tmp.push({
           key,
           error: "invalid",
@@ -173,7 +183,7 @@ const validateData = (data: Record<string, any>, validator: Record<string, any>)
       }
     }
     if (rule.regex) {
-      if (!rule.regex.test(data[key])) {
+      if (!rule.regex.test(String(record[key]))) {
         tmp.push({
           key,
           error: "regexError",


### PR DESCRIPTION
## Summary
\`functions/\` 配下の \`any\` を型定義で除去。
firebase.json の predeploy で src/ から コピーされるファイル（RestaurantInfo.ts, commonUtils.ts）は対象外。

## 変更内容

### \`functions/src/functions/image/imageUtil.ts\`
\`splitMatchPath[key as any]\` → \`splitMatchPath[Number(key)]\` に変更（line 80 と同じパターン）。

### \`functions/src/functions/order/orderUpdate.ts\`
\`\`\`diff
-await transaction.update(orderRef, updateData as any);
+await transaction.update(
+  orderRef,
+  updateData as admin.firestore.UpdateData<OrderData>,
+);
\`\`\`

\`UpdateDataOnOrderUpdate\` 型を firestore が要求する \`UpdateData<OrderData>\` へ narrow。

### \`functions/src/lib/validator.ts\`
\`validateData\` の引数型を追加:
- \`data: Record<string, any>\` → \`data: object\`（内部で \`Record<string, unknown>\` に cast）
- \`validator: Record<string, any>\` → \`validator: Record<string, ValidatorRule>\`
- \`rule.regex.test(data[key])\` は \`String()\` でラップして型を合わせた

## 対象外（firebase.json predeploy copy）
- \`functions/src/models/RestaurantInfo.ts\` — \`src/models/RestaurantInfo.ts\` のコピー（src/ 側は修正済み）
- \`functions/src/utils/commonUtils.ts\` — \`src/utils/commonUtils.ts\` のコピー（src/ 側は修正済み）

次回 deploy 時に copy2functions.sh で最新版に上書きされるため、ここでは対応不要。

## Test plan
- [x] \`yarn lint\` 通過（6 warnings は全て上記 copy 対象ファイル）
- [x] \`yarn build\` 通過

型の変更のみで runtime 挙動は変わらないため動作テスト不要。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced type safety and improved validation logic for image processing operations to ensure more reliable image handling
  * Strengthened TypeScript type definitions for Firestore transaction operations in order management to better ensure data consistency
  * Upgraded data validation framework with improved type definitions and more robust validation rule evaluation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->