### PR TITLE
chore: 未使用の use_jp / use_staging スクリプトを削除

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,8 +16,6 @@
     "customclaims": "babel-node --presets @babel/env  ./batch/customclaims.js",
     "format": "prettier --write '{src/**/*,*}.{js,ts,vue,json,css}'",
     "makenews": "npx tsx ./batch/news.js",
-    "use_jp": "firebase use jp && cp src/config/default/ownplate-jp.js src/config/project.js",
-    "use_staging": "firebase use staging && cp src/config/default/ownplate-dev.js src/config/project.js",
     "user": "babel-node --presets @babel/env  ./batch/user.js"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary

- `package.json` から未使用の `use_jp` と `use_staging` スクリプトを削除
- どちらも cp 先が `.js` 拡張子を参照しているが、`src/config/default/` の実ファイルは全て `.ts` のため実行時に失敗する状態だった
- リーダー確認のうえ削除（Slack にて承認済み）

Closes #1638

## User Prompt

> 「プルリク1634のCLAUDE.md からは、環境切り替えセクションを丸ごと削除し、package.json の use_jp / use_staging は別のプルリクで削除」で、リーダーがOKしました。進めてください。

## 関連

- PR #1635 で既に `use_production` は削除済み
- PR #1634 (CLAUDE.md) では環境切り替えセクションを削除する対応を並行で実施

## Test plan

- [ ] `git diff` で `package.json` の変更が scripts 2 行の削除のみであることを確認
- [ ] `yarn install` がエラーなく通ること
- [ ] 既存の CI が通ること