### PR TITLE
fix: rename reorder button label to clarify drag operation

### DIFF
--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -337,7 +337,7 @@ const data = {
     item: "Item",
     noItem: "No Item",
     pleaseAddItem: "Please create your menu from the bottom button.",
-    reorder: "Reorder",
+    reorder: "Drag to Reorder",
     doneReorder: "Done",
     required: "Required",
     itemName: "Item name",

--- a/src/lang/fr.ts
+++ b/src/lang/fr.ts
@@ -315,7 +315,7 @@ const data = {
     item: "Item",
     noItem: "No Item",
     pleaseAddItem: "Please create your menu from the bottom button.",
-    reorder: "Réorganiser",
+    reorder: "Glisser pour réorganiser",
     doneReorder: "Terminé",
     required: "Required",
     itemName: "Item name",

--- a/src/lang/ja.ts
+++ b/src/lang/ja.ts
@@ -337,7 +337,7 @@ const data = {
     item: "商品",
     noItem: "何も登録されていません",
     pleaseAddItem: "下のボタンを押して商品を追加して下さい。",
-    reorder: "並び替え",
+    reorder: "ドラッグで並び替え",
     doneReorder: "完了",
     required: "必須",
     itemName: "商品名",


### PR DESCRIPTION
## Summary

メニュー並び替えボタンのラベルを、ドラッグ操作であることが伝わるよう修正。

- ja: `並び替え` → `ドラッグで並び替え`
- en: `Reorder` → `Drag to Reorder`
- fr: `Réorganiser` → `Glisser pour réorganiser`

## 変更ファイル

- `src/lang/ja.ts`
- `src/lang/en.ts`
- `src/lang/fr.ts`

## Summary by Sourcery

Bug Fixes:
- Improve the reorder button text in Japanese, English, and French to explicitly describe drag-based reordering.