### PR TITLE
fix: apply notranslate globally via index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width,initial-scale=1.0">
+    <meta name="google" content="notranslate">
     <link rel="icon" href="/favicon.ico">
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons%7CMaterial+Icons+Outlined" rel="stylesheet">
     <title>おもちかえり.com</title>

--- a/src/config/header.ts
+++ b/src/config/header.ts
@@ -82,7 +82,8 @@ export const RestaurantHeader = {
   meta: [
     { charset: "utf-8" },
     { name: "viewport", content: "width=device-width, initial-scale=1" },
-    { name: "google", content: "notranslate" },
+    // notranslate is set globally in index.html so all pages opt out of
+    // browser auto-translation, not just RestaurantHeader-using ones.
   ],
   link,
 };


### PR DESCRIPTION
## Summary
`<meta name=\"google\" content=\"notranslate\">` を `RestaurantHeader.meta` から静的 `index.html` に移動。これで全ページ（`/r/:restaurantId`, `/o/:ownerId`, `/admin/*`, Profile, OrderPage, Terms 等）で Chrome の自動翻訳が抑止される。

## 背景

PR #1656 で `header.ts` の unhead v3 移行をした際、`notranslate` は `RestaurantHeader.meta` に残していた。その後の調査で、`RestaurantHeader` を `useHead` する画面が **3 つだけ** であることが判明:
- \`/r\` (RootPage)
- \`/r/area/all\` (Restaurants/All)
- Favorites

それ以外の画面（特に \`/r/:restaurantId\` の店舗詳細・注文画面）は \`defaultHeader\` か個別 \`useHead\` を使っており、**notranslate が効いていなかった**。結果、Chrome の自動翻訳が自前の vue-i18n 文字列に二重に被さって、ブランド名（「おもちかえり.com」等）や UI 文言が壊れる副作用が発生していた。

## 確認事項（最小テスト）

dev / staging で:

- [ ] Chrome で英語以外の言語設定にして \`/r/:restaurantId\` を開く → 「翻訳しますか？」のバナーが出ない
- [ ] DevTools > Elements で \`<head>\` 内に \`<meta name=\"google\" content=\"notranslate\">\` が存在
- [ ] 言語セレクターで切替たときも自動翻訳がトリガされない

## Items to Confirm / Review
- 静的 \`index.html\` に置いたため **クローラ・JS 無効環境にも効く**（unhead 経由のときは Vue ハイドレーション後だった）
- \`RestaurantHeader.meta\` 側はコメント付きで削除（重複防止）
- \`defaultHeader\` 側は元々 notranslate を持っていなかったので変更なし

## User Prompt
> chromeとかが勝手に翻訳して副作用があるので、Cで。1656にコメントして修正。べつPRで。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bug Fixes:
- Prevent browser auto-translation from interfering with app-managed translations by setting the notranslate meta tag on all pages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated translation configuration to prevent Google from offering automatic translation across all pages site-wide.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->