### PR TITLE
fix: unsubscribe Firestore listener in TransactionsAct/Contents.vue

### DIFF
--- a/src/app/user/TransactionsAct/Contents.vue
+++ b/src/app/user/TransactionsAct/Contents.vue
@@ -229,7 +229,7 @@
   </div>
 </template>
 <script lang="ts">
-import { defineComponent, ref, computed, PropType } from "vue";
+import { defineComponent, ref, computed, onUnmounted, PropType } from "vue";
 
 import { daysOfWeek } from "@/config/constant";
 import { db } from "@/lib/firebase/firebase9";
@@ -258,9 +258,13 @@ export default defineComponent({
 
     const uid = props.shopInfo.uid;
 
-    onSnapshot(doc(db, `/admins/${uid}/public/payment`), (snapshot) => {
-      paymentInfo.value = snapshot.data() || {};
-    });
+    const detachPayment = onSnapshot(
+      doc(db, `/admins/${uid}/public/payment`),
+      (snapshot) => {
+        paymentInfo.value = snapshot.data() || {};
+      },
+    );
+    onUnmounted(() => detachPayment());
 
     const { nationalPhoneNumber } = useNationalPhoneNumber(props.shopInfo);
 


### PR DESCRIPTION
## Summary
\`/r/:id\` の特商法ページに表示するたびに \`onSnapshot\` listener が漏れていたのを cleanup 追加。

## 確認事項
- 動作変化なし（cleanup 追加のみ）
- build / lint OK

## 出典
\`docs/code_review_vue_2026-04-30.md\` U-CRIT-1

Closes #1672

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bug Fixes:
- Stop leaking Firestore onSnapshot listeners for the payment document by unsubscribing on component unmount.