### PR TITLE
chore: clean up admin console.log debug noise

### DIFF
--- a/src/app/admin/Index.vue
+++ b/src/app/admin/Index.vue
@@ -441,7 +441,7 @@ export default defineComponent({
                 );
                 watchOrder();
               } catch (error) {
-                console.log("Error fetch doc,", error);
+                console.error("Error fetch doc,", error);
               } finally {
                 readyToDisplay.value = true;
               }
@@ -481,7 +481,7 @@ export default defineComponent({
                   // if subAccounts has more than 11 restaurant, this will call multiple. TODO: optimize.
                   watchOrder();
                 } catch (error) {
-                  console.log("Error fetch doc,", error);
+                  console.error("Error fetch doc,", error);
                 } finally {
                   readyToDisplay.value = true;
                 }
@@ -494,7 +494,7 @@ export default defineComponent({
           scrollToElementById(location.hash.replace("#", ""));
         }
       } catch (error) {
-        console.log("Error fetch doc,", error);
+        console.error("Error fetch doc,", error);
       } finally {
         readyToDisplay.value = true;
       }
@@ -533,7 +533,6 @@ export default defineComponent({
       }
     };
     const handleNew = async () => {
-      console.log("handleNew");
       if (isOwner.value) {
         try {
           const newDoc = doc(collection(db, "restaurants"));
@@ -554,7 +553,7 @@ export default defineComponent({
           router.push(`/admin/restaurants/${newDoc.id}`);
         } catch (error) {
           dialogStore.setErrorMessage({});
-          console.log(error);
+          console.error(error);
         }
       }
     };

--- a/src/app/admin/Messages/MessageCard.vue
+++ b/src/app/admin/Messages/MessageCard.vue
@@ -75,7 +75,6 @@ export default defineComponent({
       });
     };
     const childInvitationDeny = () => {
-      console.log("deny");
       dialogStore.setAlert({
         code: "admin.messages.childInvitationDeny",
         callback: async () => {

--- a/src/app/admin/Order/OrderedInfo.vue
+++ b/src/app/admin/Order/OrderedInfo.vue
@@ -298,7 +298,7 @@ export default defineComponent({
           restaurant.value = snapshot.data() as RestaurantInfoData;
         })
         .catch(() => {
-          console.log("no restaurant");
+          console.error("no restaurant");
         });
     }
 

--- a/src/app/admin/Order/PaymentCancelModal.vue
+++ b/src/app/admin/Order/PaymentCancelModal.vue
@@ -106,16 +106,13 @@ export default defineComponent({
 
     const updating = ref(false);
     const handlePaymentCancel = async () => {
-      console.log("handlePaymentCancel");
-
       try {
         generalStore.setLoading(true);
         updating.value = true;
-        const { data } = await stripePaymentCancelIntent({
+        await stripePaymentCancelIntent({
           restaurantId: props.shopInfo.restaurantId,
           orderId: props.orderId,
         });
-        console.log("paymentCancel", data);
         router.push(props.parentUrl);
       } catch (error) {
         console.error(errorMessage(error), error);

--- a/src/app/admin/Order/ReportDetails.vue
+++ b/src/app/admin/Order/ReportDetails.vue
@@ -321,7 +321,7 @@ export default defineComponent({
                 ),
               });
             } catch (e) {
-              console.log(e);
+              console.error(e);
               // sometime data was broken
             }
           });

--- a/src/app/admin/Restaurants/Index.vue
+++ b/src/app/admin/Restaurants/Index.vue
@@ -1359,7 +1359,6 @@ export default defineComponent({
       countryCode: string;
       errors: string[];
     }) => {
-      //console.log(payload)
       editShopInfo.phoneNumber = payload.phoneNumber;
       editShopInfo.countryCode = payload.countryCode;
       errorsPhone.value = payload.errors;

--- a/src/app/admin/Restaurants/ManageLine.vue
+++ b/src/app/admin/Restaurants/ManageLine.vue
@@ -150,7 +150,6 @@ export default defineComponent({
     const state = route.query.state as string;
     if (lineId && displayName && state) {
       if (lineVerify(state)) {
-        console.log(displayName, uid.value, restaurantId.value);
         setDoc(
           doc(db, `restaurants/${restaurantId.value}/lines/${lineId}`),
           {
@@ -160,9 +159,7 @@ export default defineComponent({
             restaurantId: restaurantId.value,
           },
           { merge: true },
-        ).then(() => {
-          console.log("registered lineId", lineId);
-        });
+        );
       } else {
         console.error("invalid state", state);
       }
@@ -202,7 +199,6 @@ export default defineComponent({
       dialogStore.setAlert({
         code: "admin.order.lineDelete",
         callback: async () => {
-          console.log("handleDelete", _lineId);
           await deleteDoc(
             doc(db, `restaurants/${restaurantId.value}/lines/${_lineId}`),
           );

--- a/src/app/admin/Restaurants/MenuItemPage.vue
+++ b/src/app/admin/Restaurants/MenuItemPage.vue
@@ -1022,7 +1022,7 @@ export default defineComponent({
           code: "menu.save",
           error,
         });
-        console.log(error);
+        console.error(error);
       }
     };
 

--- a/src/app/admin/Restaurants/MenuListPage.vue
+++ b/src/app/admin/Restaurants/MenuListPage.vue
@@ -343,7 +343,7 @@ export default defineComponent({
         } else {
           notFound.value = true;
           // 404
-          console.log("Error fetch shopInfoSnapshot.");
+          console.error("Error fetch shopInfoSnapshot.");
         }
       },
     );

--- a/src/app/admin/Restaurants/OrderInfoPage.vue
+++ b/src/app/admin/Restaurants/OrderInfoPage.vue
@@ -952,7 +952,6 @@ export default defineComponent({
       );
 
       const deliveryFee = (() => {
-        // console.log(deliveryData.value.enableDeliveryFree, ret.total , deliveryData.value.deliveryThreshold);
         if (!props.shopInfo.enableDelivery) {
           return 0;
         }
@@ -1032,7 +1031,6 @@ export default defineComponent({
     const handleChangeStatus = async (statusKey: string) => {
       const newStatus = order_status[statusKey];
       if (newStatus === orderInfo.value.status) {
-        console.log("same status - no need to process");
         return;
       }
       updating.value = statusKey;
@@ -1052,7 +1050,6 @@ export default defineComponent({
           params.timeEstimated = getEestimateTime();
         }
         const { data } = await orderUpdate(params);
-        // console.log("update", data);
         if (data.result) {
           router.push(parentUrl.value);
         } else {
@@ -1094,8 +1091,7 @@ export default defineComponent({
             await orderChange(params);
             isOrderChange.value = false;
 
-            // console.log("update", data);
-          } catch (error) {
+              } catch (error) {
             console.error(errorMessage(error), error);
             dialogStore.setErrorMessage({
               code: "order.update",
@@ -1120,7 +1116,6 @@ export default defineComponent({
       cancelPopup.value = false;
     };
     const openPaymentCancel = () => {
-      console.log("openPaymentCancel");
       paymentCancelPopup.value = true;
     };
     const closePaymentCancel = () => {

--- a/src/app/admin/Restaurants/QRCode.vue
+++ b/src/app/admin/Restaurants/QRCode.vue
@@ -48,7 +48,6 @@ export default defineComponent({
 
     const download = () => {
       const a = document.createElement("a");
-      console.log(qrcodeRef);
       a.href = qrcodeRef.value.$el.toDataURL("image/png");
       a.download = "qrcode.png";
       a.click();

--- a/src/app/admin/Smaregi/Callback.vue
+++ b/src/app/admin/Smaregi/Callback.vue
@@ -48,7 +48,6 @@ export default defineComponent({
           const { data } = await smaregiAuth({
             code: code,
           });
-          console.log("smaregiAuth", data);
           if (data.result) {
             router.push("/admin/smaregi/index");
           } else {

--- a/src/app/admin/Smaregi/Index.vue
+++ b/src/app/admin/Smaregi/Index.vue
@@ -264,8 +264,7 @@ export default defineComponent({
             isLoading.value = true;
             const { data } = await smaregiStoreList({});
             shopList.value = data.res;
-            // console.log("smaregiStoreList", data);
-          } finally {
+            } finally {
             isLoading.value = false;
           }
           const restaurantColleciton = await getDocs(
@@ -323,7 +322,7 @@ export default defineComponent({
 
     const saveShops = () => {
       if (isDuplicateError.value) {
-        console.log("error");
+        console.error("error");
         return;
       }
 
@@ -358,10 +357,8 @@ export default defineComponent({
             data.inStock = inStock;
           }
           setDoc(doc(db, path), data);
-          // console.log(selectedRestaurant.value[key]);
         } else {
           deleteDoc(doc(db, path));
-          console.log("TODO DELETE");
         }
       });
       isEdit.value = false;

--- a/src/app/admin/Smaregi/Store.vue
+++ b/src/app/admin/Smaregi/Store.vue
@@ -251,13 +251,13 @@ export default defineComponent({
           });
           selectedMenu.value = _selectedMenu;
         } catch (e) {
-          console.log(e);
+          console.error(e);
         }
       },
     );
     const saveMenus = () => {
       if (isDuplicateError.value) {
-        console.log("error");
+        console.error("error");
         return;
       }
       (productList.value || []).forEach((product, key) => {


### PR DESCRIPTION
## Summary
admin/ 配下の \`console.log\` 60 箇所を整理:
- 純粋 debug ログを削除（handleNew, handlePaymentCancel, deny, openPaymentCancel ほか）
- catch 節等の error 文脈ログは \`console.error\` に昇格（メッセージは原文維持）
- コメントアウト済 \`// console.log\` は削除
- \`Watcher/*\` の \`console.warn(\"Ignoring\", error.code)\` は残す（フォールバック挙動の可視化）

After: 60 → 42（残り 42 はすべて \`console.error\` / \`console.warn\`）

## 確認事項
- 動作変化なし（ログ整理のみ）
- build / lint OK

## 出典
\`docs/code_review_vue_2026-04-30.md\` B-HIGH-2

Closes #1674

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Clean up admin UI logging by removing noisy debug output and standardizing remaining logs as warnings or errors.

Enhancements:
- Promote admin error-context console.log statements to console.error for clearer error reporting.
- Remove unused and commented-out console.log debug statements across admin components to reduce log noise.