### PR TITLE
refactor: extract YYYY-MM-DD formatting from useGeneralStore

### DIFF
--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -2,7 +2,7 @@ import { ref } from "vue";
 import { defineStore } from "pinia";
 
 import { OrderInfoData } from "@/models/orderInfo";
-import moment from "moment";
+import { formatDateYMD } from "@/utils/dateUtils";
 
 export const useGeneralStore = defineStore("generalStore", () => {
   const date = ref(new Date());
@@ -40,7 +40,7 @@ export const useGeneralStore = defineStore("generalStore", () => {
   const setOrders = (orders: OrderInfoData[]) => {
     orderObj.value = orders.reduce(
       (tmp: { [key: string]: OrderInfoData[] }, order: OrderInfoData) => {
-        const day = moment(order.timePlaced.toDate()).format("YYYY-MM-DD");
+        const day = formatDateYMD(order.timePlaced.toDate());
         if (!tmp[day]) {
           tmp[day] = [];
         }

--- a/src/utils/dateUtils.ts
+++ b/src/utils/dateUtils.ts
@@ -1,3 +1,10 @@
+export const formatDateYMD = (date: Date): string => {
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, "0");
+  const d = String(date.getDate()).padStart(2, "0");
+  return `${y}-${m}-${d}`;
+};
+
 export const midNight = (delta = 0) => {
   const date = new Date();
   date.setHours(0); // local midnight


### PR DESCRIPTION
## Summary
\`store/index.ts\` で直接 \`moment\` を呼んでいた箇所を \`utils/dateUtils.ts\` の \`formatDateYMD()\` ヘルパに抽出。

## 確認事項
- 出力は \`moment(d).format(\"YYYY-MM-DD\")\` と byte-identical（境界ケース：年/月ロールオーバー、閏日、月中で確認済）
- ストアは moment 依存を持たなくなった（date library swap 時の影響範囲が狭くなる）
- build / lint OK

## 出典
\`docs/code_review_vue_2026-04-30.md\` S-HIGH-4

Closes #1676

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Extract date formatting logic into a shared utility and remove direct moment usage from the general store.

Enhancements:
- Add a reusable formatDateYMD helper in dateUtils for YYYY-MM-DD date strings.
- Refactor the general store to use the shared date formatting helper instead of moment, eliminating the store's direct dependency on moment.