### PR TITLE
refactor: simplify userStore type union

### DIFF
--- a/src/store/user.ts
+++ b/src/store/user.ts
@@ -12,62 +12,37 @@ interface Claims {
 }
 
 export const useUserStore = defineStore("userStore", () => {
-  const user = ref<undefined | boolean | User>(undefined);
+  const user = ref<User | null | undefined>(undefined);
+  const claims = ref<Claims | null | undefined>(undefined);
 
-  const claims = ref<undefined | Claims>(undefined);
+  const uid = computed(() => user.value?.uid);
+  const uidAdmin = computed(() =>
+    user.value?.email ? user.value.uid : undefined,
+  );
+  const uidUser = computed(() =>
+    user.value?.phoneNumber ? user.value.uid : undefined,
+  );
+  const uidLiff = computed(() =>
+    user.value && claims.value?.liffId ? user.value.uid : undefined,
+  );
+  const liffId = computed(() =>
+    user.value ? claims.value?.liffId : undefined,
+  );
+  const isAnonymous = computed(
+    () => user.value === undefined || user.value === null,
+  );
+  const isSuperAdmin = computed(() => claims.value?.admin);
+  const isNotSuperAdmin = computed(() => !claims.value?.admin);
+  const isOperator = computed(() => claims.value?.operator);
+  const isNotOperator = computed(() => !claims.value?.operator);
+  const isAdmin = computed(() => !!(user.value?.email && user.value?.uid));
+  const isSubAccount = computed(() => !!claims.value?.parentUid);
+  const parentId = computed(() => claims.value?.parentUid);
 
-  const uid = computed(() => {
-    return user.value && (user.value as User).uid;
-  });
-  const uidAdmin = computed(() => {
-    return user.value && (user.value as User).email && (user.value as User).uid;
-  });
-  const uidUser = computed(() => {
-    return (
-      user.value && (user.value as User).phoneNumber && (user.value as User).uid
-    );
-  });
-  const uidLiff = computed(() => {
-    return (
-      user.value && (claims.value as Claims).liffId && (user.value as User).uid
-    );
-  });
-  const liffId = computed(() => {
-    return user.value && claims.value?.liffId;
-  });
-  const isAnonymous = computed(() => {
-    return user.value === undefined || user.value === null;
-  });
-  const isSuperAdmin = computed(() => {
-    return claims.value?.admin;
-  });
-  const isNotSuperAdmin = computed(() => {
-    return !claims.value?.admin;
-  });
-  const isOperator = computed(() => {
-    return claims.value?.operator;
-  });
-  const isNotOperator = computed(() => {
-    return !claims.value?.operator;
-  });
-  const isAdmin = computed(() => {
-    return !!(
-      user.value &&
-      (user.value as User).email &&
-      (user.value as User).uid
-    );
-  });
-  const isSubAccount = computed(() => {
-    return !!claims.value?.parentUid;
-  });
-  const parentId = computed(() => {
-    return claims.value?.parentUid;
-  });
-
-  const setUser = (_user: User) => {
+  const setUser = (_user: User | null) => {
     user.value = _user;
   };
-  const setCustomClaims = (_claims: Claims) => {
+  const setCustomClaims = (_claims: Claims | null) => {
     // Note: we can't copy user using Object.assign here
     claims.value = _claims;
   };


### PR DESCRIPTION
## Summary
\`store/user.ts\` の \`user\` ref を \`undefined | boolean | User\` から \`User | null | undefined\` に整理。\`as User\` キャスト 7 箇所を optional chaining に置換。\`setUser\`/\`setCustomClaims\` も \`null\` を許容する正しい型に。

## 確認事項
- 動作変化なし（computeds の戻り値は falsy/truthy で従来と等価、消費側は truthy チェック or property アクセスのみ）
- App.vue の \`setUser(null)\` / \`setCustomClaims(null)\` が型整合になる（これまで Pinia の loose 型推論で素通りしていた）
- build / lint OK

## 出典
\`docs/code_review_vue_2026-04-30.md\` S-HIGH-2

Closes #1681

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Refine the user store state and computed properties to use precise nullable types for user and claims without changing runtime behavior.

Enhancements:
- Normalize the user and claims refs to use explicit `User | null | undefined` and `Claims | null | undefined` types and replace unsafe type casts with optional chaining in computed properties.
- Allow `setUser` and `setCustomClaims` to accept `null` to align with actual usage while preserving existing truthy/falsy semantics of derived values.