### PR TITLE
fix: unsubscribe Firestore listeners in admin Printer / DiscountHistory

### DIFF
--- a/src/app/admin/Restaurants/Discount/DiscountHistory.vue
+++ b/src/app/admin/Restaurants/Discount/DiscountHistory.vue
@@ -130,7 +130,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, ref } from "vue";
+import { defineComponent, ref, onUnmounted } from "vue";
 
 import { db } from "@/lib/firebase/firebase9";
 import {
@@ -194,7 +194,7 @@ export default defineComponent({
         );
     const q = query(cond, orderBy("createdAt", "desc"));
 
-    onSnapshot(q, (docs) => {
+    const detachHistories = onSnapshot(q, (docs) => {
       const tmp: HistoryItem[] = [];
       docs.docs.forEach((a) => {
         const d = a.data();
@@ -203,6 +203,7 @@ export default defineComponent({
       });
       histories.value = tmp;
     });
+    onUnmounted(() => detachHistories());
 
     const deleteHistory = (history: HistoryItem) => {
       deleteDoc(doc(db, history.path));

--- a/src/app/admin/Restaurants/Printer.vue
+++ b/src/app/admin/Restaurants/Printer.vue
@@ -67,7 +67,7 @@
 </template>
 
 <script>
-import { defineComponent, ref, computed } from "vue";
+import { defineComponent, ref, computed, onUnmounted } from "vue";
 import { db } from "@/lib/firebase/firebase9";
 import { doc, collection, onSnapshot, setDoc } from "firebase/firestore";
 
@@ -103,7 +103,7 @@ export default defineComponent({
       const newKey = doc(collection(db, "a")).id;
       setDoc(restaurantRef, { key: newKey }, { merge: true });
     };
-    onSnapshot(restaurantRef, (_doc) => {
+    const detachPrinter = onSnapshot(restaurantRef, (_doc) => {
       const data = _doc.data();
       if (data === undefined) {
         reset();
@@ -111,6 +111,7 @@ export default defineComponent({
       printerConfig.value = data || {};
       notFound.value = false;
     });
+    onUnmounted(() => detachPrinter());
 
     const printerAddress = computed(() => {
       if (printerConfig.value?.key) {


### PR DESCRIPTION
## Summary
admin/ 配下 16 ファイル / 41 onSnapshot 監査の結果、cleanup 漏れを発見した 2 件を修正:
- \`Printer.vue:106\` — プリンタ設定 doc listener
- \`DiscountHistory.vue:197\` — 割引履歴 collection-group listener

両方 \`const detacher = onSnapshot(...)\` + \`onUnmounted(() => detacher())\` で解除。

## 確認事項
- 他 14 ファイルは Unsubscribe + onUnmounted パターン済み（spot check 済）
- 動作変化なし（cleanup 追加のみ）
- build / lint OK

## 出典
\`docs/code_review_vue_2026-04-30.md\` B-HIGH-3

Closes #1688

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Ensure Firestore listeners in admin discount history and printer views are properly unsubscribed on component unmount to prevent leaked real-time subscriptions.

Bug Fixes:
- Add unsubscription for the discount history collection-group Firestore listener when the component is unmounted.
- Add unsubscription for the restaurant printer configuration Firestore listener when the component is unmounted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced resource cleanup in the Discount History and Printer components to properly manage Firestore listener lifecycle and prevent potential memory leaks when navigating away from these admin sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->