### PR TITLE
chore: remove commented-out useToggle import in RestaurantPage

### DIFF
--- a/src/app/user/RestaurantPage.vue
+++ b/src/app/user/RestaurantPage.vue
@@ -320,7 +320,6 @@ import {
   getPrices,
   getTrimmedSelectedOptions,
   getPostOption,
-  // useToggle,
   scrollToElementById,
   useUserData,
   useBasePath,


### PR DESCRIPTION
## Summary
\`RestaurantPage.vue\` のインポートリストに残っていた \`// useToggle,\` 行を削除。

## 確認事項
- 動作変化なし（コメント削除のみ）
- build / lint OK

## 出典
\`docs/code_review_vue_2026-04-30.md\` U-MED-3

Closes #1690

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Chores:
- Clean up RestaurantPage.vue imports by deleting a leftover commented-out useToggle entry.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Code cleanup and import refinement in the restaurant page component to ensure proper utility function availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->