### PR TITLE
chore: convert deep relative store imports to @/ alias

### DIFF
--- a/src/app/admin/Watcher/SoundConfigWatcher.vue
+++ b/src/app/admin/Watcher/SoundConfigWatcher.vue
@@ -7,7 +7,7 @@ import { defineComponent, watch } from "vue";
 
 import { soundFiles } from "@/config/constant";
 import { getSoundIndex } from "@/utils/utils";
-import { useGeneralStore } from "../../../store";
+import { useGeneralStore } from "@/store";
 
 export default defineComponent({
   props: {

--- a/src/app/user/Restaurant/CartItem.vue
+++ b/src/app/user/Restaurant/CartItem.vue
@@ -85,7 +85,7 @@ import Price from "@/components/Price.vue";
 import { RestaurantInfoData } from "@/models/RestaurantInfo";
 import { MenuData } from "@/models/menu";
 import { AnalyticsMenuData } from "@/lib/firebase/analytics";
-import { useGeneralStore } from "../../../store";
+import { useGeneralStore } from "@/store";
 
 import moment from "moment-timezone";
 

--- a/src/app/user/Restaurant/Menu.vue
+++ b/src/app/user/Restaurant/Menu.vue
@@ -448,7 +448,7 @@ import moment from "moment-timezone";
 //   if button push, quantities.push(1)
 //   when update quantities, if there is 0 element in quantities and quantities.size > 0, filter 0 element in quantities.
 
-import { useGeneralStore } from "../../../store";
+import { useGeneralStore } from "@/store";
 import { useRoute, useRouter } from "vue-router";
 import { useI18n } from "vue-i18n";
 

--- a/src/components/App/NotificationBanner.vue
+++ b/src/components/App/NotificationBanner.vue
@@ -10,7 +10,7 @@
 
 <script lang="ts">
 import { defineComponent, ref, computed, watch } from "vue";
-import { useGeneralStore } from "../../store";
+import { useGeneralStore } from "@/store";
 
 export default defineComponent({
   setup() {


### PR DESCRIPTION
## Summary
\`../../store\` / \`../../../store\` だった 4 箇所の Pinia store import を \`@/store\` 統一。

## 確認事項
- 動作変化なし（pure refactor）
- build / lint OK

## スコープ外
\`Docs/Article.vue\` の \`../../../../docs/article*.md\` 8 件は src/ 外参照のため別 PR で対応。

## 出典
\`docs/code_review_vue_2026-04-30.md\` S-MED-2

Closes #1692

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Enhancements:
- Normalize store import paths from deep relative references to the @/store alias across admin and user-facing Vue components to improve consistency and maintainability.