### PR TITLE
fix: scope AppCheck debug token to dev mode

### DIFF
--- a/src/lib/firebase/firebase9.ts
+++ b/src/lib/firebase/firebase9.ts
@@ -5,7 +5,7 @@ import { firebaseConfig, appCheckKey } from "@/config/project";
 
 const firebaseApp = initializeApp(firebaseConfig);
 
-if (location.hostname === "localhost") {
+if (import.meta.env.DEV && location.hostname === "localhost") {
   self.FIREBASE_APPCHECK_DEBUG_TOKEN = true;
 }
 


### PR DESCRIPTION
## Summary
\`FIREBASE_APPCHECK_DEBUG_TOKEN = true\` を \`import.meta.env.DEV\` ガード付きに変更。本番ビルドが localhost で動いた場合の AppCheck 意図せぬバイパスを防ぐ。

## 確認事項
- \`yarn dev\` 上の挙動は不変
- 本番デプロイ環境にも影響なし
- build / lint OK

## 出典
\`docs/code_review_vue_2026-04-30.md\` S-MED-5

Closes #1694

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bug Fixes:
- Prevent App Check from being automatically bypassed in production builds that happen to run on localhost by additionally requiring development mode for the debug token.