### PR TITLE
fix: add submitting guard to SignUp button (U-HIGH-3)

### DIFF
--- a/plans/fix-U-HIGH-3-signup-submitting-guard.md
+++ b/plans/fix-U-HIGH-3-signup-submitting-guard.md
@@ -1,0 +1,39 @@
+# U-HIGH-3: SignUp ボタンに submitting ガード追加
+
+Issue: #1696
+Refs: `omochikaeri-docs/Docs/code_review_vue_2026-04-30.md` U-HIGH-3
+
+## 問題
+
+`src/app/auth/SignUpPage.vue` の `onSignup` は async で複数の Firestore / Auth 操作を順に実行する。
+
+現状の submit ボタン:
+
+```vue
+<t-submit :isDisabled="submitted && Object.keys(errors).length > 0">
+```
+
+`errors` が空の正常系では `:isDisabled` が常に `false` のままで、async 処理中もボタンが押せる。連打すると `createUserWithEmailAndPassword` が複数回走り、2 回目以降は `auth/email-already-in-use` で失敗する想定だが、防御的ではない。
+
+`generalStore.setLoading(true)` でグローバルなローディング表示は出るが、ボタン自身は disabled にならず、a11y/UX 上も望ましくない。
+
+## 修正方針
+
+1. `submitting` ref を追加 (in-flight フラグ)
+2. `onSignup` 内で hasError チェック後に `submitting.value = true`、finally で false にリセット
+3. `:isDisabled` を `submitting || (submitted && Object.keys(errors).length > 0)` に変更
+4. setup の return に `submitting` を追加
+
+## 変更ファイル
+
+- `src/app/auth/SignUpPage.vue` のみ
+
+## 影響範囲
+
+- 機能変更なし（防御的ガードのみ）
+- 既存の `setLoading` 連動オーバーレイ表示と並列に動作
+
+## 検証
+
+- `yarn lint` / `yarn build` 成功
+- 手動 UI テストは不要（防御的ガード、submit ボタンが押せなくなるだけ）

--- a/src/app/auth/SignUpPage.vue
+++ b/src/app/auth/SignUpPage.vue
@@ -126,7 +126,9 @@
           </t-button>
 
           <t-submit
-            :isDisabled="submitted && Object.keys(errors).length > 0"
+            :isDisabled="
+              submitting || (submitted && Object.keys(errors).length > 0)
+            "
             class="h-12 w-32 font-bold text-white"
           >
             {{ $t("button.next") }}
@@ -134,7 +136,11 @@
         </div>
 
         <!-- Terms of Use & Privacy Policy -->
-        <I18nT keypath="auth.signupTerms.message" tag="div" class="mt-2 text-xs">
+        <I18nT
+          keypath="auth.signupTerms.message"
+          tag="div"
+          class="mt-2 text-xs"
+        >
           <template #terms>
             <router-link to="/terms/admin" target="_blank">
               <span class="text-op-teal">{{
@@ -211,6 +217,7 @@ export default defineComponent({
     const deferredPush = ref(false);
     const emailTaken = ref("---invalid---");
     const submitted = ref(false);
+    const submitting = ref(false);
     const showTotpEnrollment = ref(false);
 
     useHead(() => ({
@@ -290,6 +297,10 @@ export default defineComponent({
       if (hasError.value) {
         return;
       }
+      if (submitting.value) {
+        return;
+      }
+      submitting.value = true;
       generalStore.setLoading(true);
       try {
         const result = await createUserWithEmailAndPassword(
@@ -319,13 +330,10 @@ export default defineComponent({
         } catch (e) {
           console.log(e);
         }
-        generalStore.setLoading(false);
 
         // Show TOTP enrollment (optional)
         showTotpEnrollment.value = true;
       } catch (error) {
-        generalStore.setLoading(false);
-
         const code = errorCode(error);
         console.warn("onSignup failed", code, errorMessage(error));
         if (code === "auth/email-already-in-use") {
@@ -333,6 +341,9 @@ export default defineComponent({
         } else {
           dialogStore.setErrorMessage({ code: "auth.signupFailed" });
         }
+      } finally {
+        generalStore.setLoading(false);
+        submitting.value = false;
       }
     };
     return {
@@ -344,6 +355,7 @@ export default defineComponent({
       deferredPush,
       emailTaken,
       submitted,
+      submitting,
       showTotpEnrollment,
 
       // computed


### PR DESCRIPTION
## Summary

- `src/app/auth/SignUpPage.vue` の submit ボタンが async サインアップ処理中も押せる状態だったため、`submitting` フラグでガードして二重送信を防ぐ
- 防御的ガードのみ。機能挙動・UI 文言は変更なし

## Items to Confirm / Review

- `:isDisabled` の式: `submitting || (submitted && Object.keys(errors).length > 0)` で従来のエラー時 disable 挙動は維持しつつ、in-flight 中も disable
- `generalStore.setLoading(false)` を `try` / `catch` の各分岐から `finally` に集約。例外時パスでも確実にローディング解除されることを再確認
- `submitting` を setup の return に追加してテンプレートから参照可能に

## User Prompt

> https://github.com/SingularitySociety/omochikaeri-docs/blob/master/Docs/code_review_vue_2026-04-30.md　対応済みなのは、(対応済み）とタイトルにつけて更新。そのほか影響はなく直せるものを引き続き進めたい

`code_review_vue_2026-04-30.md` の U-HIGH-3 として挙がっていた、SignUp ボタンの二重送信防止策。レビュー指摘の中で「機能影響なく安全に直せるもの」を引き続き処理する流れの一環。

## Implementation

1. `submitting` ref を追加
2. `onSignup` 内で hasError チェック後・前回の in-flight チェック後に `submitting.value = true`
3. async 処理を `try / catch / finally` 構造に再編し、`finally` で `setLoading(false)` と `submitting.value = false` をまとめてリセット
4. `:isDisabled` を `submitting || (submitted && Object.keys(errors).length > 0)` に変更
5. setup の return に `submitting` を追加

Plan: `plans/fix-U-HIGH-3-signup-submitting-guard.md`

Closes #1696

## Summary by Sourcery

Prevent duplicate submissions on the SignUp page by guarding the async sign-up flow with a submitting state and ensuring loading state is always reset.

Bug Fixes:
- Disable the SignUp submit button while an async sign-up request is in flight to prevent duplicate submissions and related errors.

Enhancements:
- Ensure global loading state and submitting flag are reliably cleared via a unified finally block in the sign-up handler.

Documentation:
- Add a plan document describing the submitting guard change for the SignUp button and its rationale.