### PR TITLE
fix: explicitly disable raw HTML in News MarkdownIt (B-MED-3)

### DIFF
--- a/plans/fix-B-MED-3-markdown-html-false.md
+++ b/plans/fix-B-MED-3-markdown-html-false.md
@@ -1,0 +1,30 @@
+# B-MED-3: News markdown — explicit `html: false`
+
+Issue: #1698
+Refs: `omochikaeri-docs/Docs/code_review_vue_2026-04-30.md` B-MED-3
+
+## 問題
+
+`src/app/admin/News/Article.vue` と `src/app/user/News.vue` で
+
+```ts
+md: new MarkdownIt(),
+```
+
+として、`v-html` でレンダリングしている。
+
+`news.markdown` は `src/app/admin/News/data.ts` にハードコードされた内部コンテンツのため XSS 実害は現状ないが、markdown-it の `html` オプションのデフォルトが `false` であることに依存している。明示的でなく、将来 admin UI から編集可能化された場合に問題化する。
+
+## 修正方針
+
+`new MarkdownIt({ html: false })` を明示。動作変更なし（デフォルト値の明示化）。
+
+## 変更ファイル
+
+- `src/app/admin/News/Article.vue`
+- `src/app/user/News.vue`
+
+## 影響範囲
+
+- 機能挙動なし（既にデフォルトで `html: false`）
+- 防御的姿勢を可視化

--- a/src/app/admin/News/Article.vue
+++ b/src/app/admin/News/Article.vue
@@ -71,7 +71,7 @@ export default defineComponent({
     }));
 
     return {
-      md: new MarkdownIt(),
+      md: new MarkdownIt({ html: false }),
       news,
     };
   },

--- a/src/app/user/News.vue
+++ b/src/app/user/News.vue
@@ -43,7 +43,7 @@ export default defineComponent({
     }));
 
     return {
-      md: new MarkdownIt(),
+      md: new MarkdownIt({ html: false }),
       newsList,
     };
   },


### PR DESCRIPTION
## Summary

- News markdown レンダリングで `new MarkdownIt({ html: false })` を明示
- markdown-it のデフォルト値の明示化なので動作変更なし

## Items to Confirm / Review

- `news.markdown` は `src/app/admin/News/data.ts` のハードコード値（admin UI から編集はできない）。raw HTML タグは現状 0 件、すべて標準 markdown 記法（`![](...)` 含む）
- `html: false` は markdown-it の **デフォルト** なので挙動は変わらない。将来 admin UI で編集可能化された場合の防御線として明示する目的
- 対象は News 経路の 2 ファイル（`News/Article.vue` と `user/News.vue`）
- `/admin/docs/articles/...` の Docs 経路は `unplugin-vue-markdown` (build-time) で別インスタンス。本 PR の影響なし（`<img>` 等の raw HTML 表示はこれまで通り）

## User Prompt

> https://github.com/SingularitySociety/omochikaeri-docs/blob/master/Docs/code_review_vue_2026-04-30.md　対応済みなのは、(対応済み）とタイトルにつけて更新。そのほか影響はなく直せるものを引き続き進めたい

`code_review_vue_2026-04-30.md` の B-MED-3 として挙がっていた項目。「機能影響なく安全に直せるもの」の継続対応。

## Implementation

`new MarkdownIt()` → `new MarkdownIt({ html: false })` の 2 箇所のみ。

Plan: `plans/fix-B-MED-3-markdown-html-false.md`

Closes #1698

## Summary by Sourcery

Clarify News markdown rendering configuration by explicitly disabling raw HTML in MarkdownIt while retaining existing behavior.

Enhancements:
- Specify `html: false` in MarkdownIt instances used for admin and user News views to make the default XSS-safe behavior explicit.

Chores:
- Add a planning document describing the B-MED-3 change to explicitly set `html: false` for News markdown rendering.