### PR TITLE
fix: replace 'as any' on i18n formats with vue-i18n public types (S-HIGH-7)

### DIFF
--- a/plans/fix-S-HIGH-7-vue-i18n-types.md
+++ b/plans/fix-S-HIGH-7-vue-i18n-types.md
@@ -1,0 +1,25 @@
+# S-HIGH-7: vue-i18n.ts の `as any` を公開型で解消
+
+Refs: `omochikaeri-docs/Docs/code_review_vue_2026-04-30.md` S-HIGH-7
+
+## 問題
+
+`src/lib/vue-i18n.ts:73-86` で `numberFormats` / `datetimeFormats` に `as any` 2 箇所と `eslint-disable @typescript-eslint/no-explicit-any` コメント。
+
+原因: 内側の `numberFormats` / `datetimeFormats` 定数に型注釈がなく、`style: "currency"` 等が `string` に widen されて `createI18n` の引数型と不整合だった。
+
+## 修正方針
+
+vue-i18n が export している `IntlNumberFormat` / `IntlDateTimeFormat`（`@intlify/core-base` の `NumberFormat` / `DateTimeFormat` の re-export、`{ [key: string]: NumberFormatOptions | DateTimeFormatOptions }` 構造）で内側の定数を明示型注釈。
+
+外側の `{ en: numberFormats, ja: numberFormats, ... }` は `createI18n` の `NumberFormats<Schema, Locales>` ジェネリックで自動推論されるので、`as any` 不要。
+
+## 変更ファイル
+
+- `src/lib/vue-i18n.ts` のみ
+
+## 影響範囲
+
+- 純型変更、ランタイム差なし
+- vue-i18n 11.4 で動作確認
+- `as any` × 2、`eslint-disable` × 2 が削除される

--- a/src/lib/vue-i18n.ts
+++ b/src/lib/vue-i18n.ts
@@ -1,4 +1,8 @@
-import { createI18n } from "vue-i18n";
+import {
+  createI18n,
+  type IntlDateTimeFormat,
+  type IntlNumberFormat,
+} from "vue-i18n";
 
 import i18nEN from "@/lang/en";
 import i18nES from "@/lang/es";
@@ -13,14 +17,14 @@ import i18nID from "@/lang/id";
 
 import { stripe_regions_jp } from "@/config/constant";
 
-const numberFormats = {
+const numberFormats: IntlNumberFormat = {
   currency: {
     style: "currency",
     currency: stripe_regions_jp.currency,
   },
 };
 
-const datetimeFormats = {
+const datetimeFormats: IntlDateTimeFormat = {
   short: {
     year: "numeric",
     month: "short",
@@ -70,8 +74,7 @@ const i18nData = {
     th: numberFormats,
     vi: numberFormats,
     id: numberFormats,
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  } as any,
+  },
   datetimeFormats: {
     en: datetimeFormats,
     ja: datetimeFormats,
@@ -82,8 +85,7 @@ const i18nData = {
     th: datetimeFormats,
     vi: datetimeFormats,
     id: datetimeFormats,
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  } as any,
+  },
 };
 const i18n = createI18n(i18nData);
 


### PR DESCRIPTION
## Summary

- `src/lib/vue-i18n.ts` の `as any` × 2 と `eslint-disable @typescript-eslint/no-explicit-any` × 2 を削除
- vue-i18n が export している `IntlNumberFormat` / `IntlDateTimeFormat` 型を内側の定数に明示注釈

## Items to Confirm / Review

- 純型変更、ランタイム差なし（`yarn build` / `yarn lint` 通過）
- 使用した `IntlNumberFormat` / `IntlDateTimeFormat` は vue-i18n 11.4 の **公開 API**（`@intlify/core-base` の `NumberFormat` / `DateTimeFormat` の re-export）
- `style: "currency"` 等のリテラルが正しく narrow され、外側の `{ en: numberFormats, ja: numberFormats, ... }` が `createI18n` の `NumberFormats<Schema, Locales>` と整合

## User Prompt

> S-HIGH-7:　これって影響なく直せる？
> vue-i18nが持っている型でたいおうできるとよいね

`code_review_vue_2026-04-30.md` の S-HIGH-7 で挙がっていた `as any` 使用箇所を、vue-i18n の公開型で解消。

## Implementation

\`\`\`ts
import {
  createI18n,
  type IntlDateTimeFormat,
  type IntlNumberFormat,
} from "vue-i18n";

const numberFormats: IntlNumberFormat = { /* ... */ };
const datetimeFormats: IntlDateTimeFormat = { /* ... */ };

// 外側の per-locale wrapper は as any なしでそのまま
const i18nData = {
  numberFormats: { en: numberFormats, ja: numberFormats, /* ... */ },
  datetimeFormats: { en: datetimeFormats, ja: datetimeFormats, /* ... */ },
};
\`\`\`

Plan: `plans/fix-S-HIGH-7-vue-i18n-types.md`

Closes #1702

## Summary by Sourcery

Replace permissive any-based typing in vue-i18n configuration with vue-i18n’s public IntlNumberFormat and IntlDateTimeFormat types to remove unsafe casts while preserving runtime behavior.

Enhancements:
- Annotate number and datetime format definitions with vue-i18n’s IntlNumberFormat and IntlDateTimeFormat types to align with the library’s public API and improve type safety.
- Remove as any casts and related ESLint no-explicit-any suppressions from the vue-i18n configuration.
- Add a short plan document describing the approach for replacing any usage in vue-i18n.ts with proper public types.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Improved TypeScript type safety by adding explicit type annotations to internal configuration objects, eliminating unnecessary type casts. No functional changes or impact to runtime behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->