### PR TITLE
refactor: remove unused cancel reasons constants (X-HIGH-1 partial)

### DIFF
--- a/plans/fix-X-HIGH-1-remove-unused-cancel-reasons.md
+++ b/plans/fix-X-HIGH-1-remove-unused-cancel-reasons.md
@@ -1,0 +1,30 @@
+# X-HIGH-1 (partial): 未使用 cancel reasons 定数の削除
+
+Refs: `omochikaeri-docs/Docs/code_review_vue_2026-04-30.md` X-HIGH-1
+
+## 問題
+
+`src/config/constant.ts:292-344` に `placedCancelReasons` / `acceptedCancelReasons` 定数（各 6 件、日本語ハードコード）。
+
+X-HIGH-1 として「constant.ts に大量の日本語ハードコード」として指摘された対象だが、コードベース全体検索で **参照ゼロ**を確認。i18n 化議論不要、削除のみ。
+
+## 検証
+
+\`\`\`bash
+grep -rn 'placedCancelReasons\|acceptedCancelReasons' src/ functions/src/
+\`\`\`
+
+`src/config/constant.ts` の宣言と `functions/src/common/constant.ts` のコピーのみ。`functions/src/common/` は `src/` からの自動コピー先で、次回 deploy 時に同期される。
+
+## 変更ファイル
+
+- `src/config/constant.ts` のみ（53 行削除）
+
+## 影響範囲
+
+- 未使用定数削除のみ、機能影響なし
+- `yarn build` 通過済み
+
+## 残作業 (X-HIGH-1 全体)
+
+本 PR は X-HIGH-1 の一部のみ。残り（`toBeOrNotSelect` / `partners.name` / Twilio TWIML 等）は別 PR で。

--- a/plans/fix-X-HIGH-1-remove-unused-cancel-reasons.md
+++ b/plans/fix-X-HIGH-1-remove-unused-cancel-reasons.md
@@ -27,4 +27,4 @@ grep -rn 'placedCancelReasons\|acceptedCancelReasons' src/ functions/src/
 
 ## 残作業 (X-HIGH-1 全体)
 
-本 PR は X-HIGH-1 の一部のみ。残り（`toBeOrNotSelect` / `partners.name` / Twilio TWIML 等）は別 PR で。
+本 PR は X-HIGH-1 の一部のみ。残り（`toBeOrNotSelect` / `partners.name` / Twilio TwiML 等）は別 PR で。

--- a/src/config/constant.ts
+++ b/src/config/constant.ts
@@ -289,60 +289,6 @@ export const soundFiles = [
   },
 ];
 
-export const placedCancelReasons = [
-  {
-    message: "キャンセル理由を必ず選択してください",
-    key: "",
-  },
-  {
-    message: "店頭在庫無し",
-    key: "placedNoStock",
-  },
-  {
-    message: "発注しないと店舗で判断",
-    key: "placedNoOrder",
-  },
-  {
-    message: "緊急取消のため発注不可",
-    key: "placedEmergency",
-  },
-  {
-    message: "お客様申し出",
-    key: "placedByCustomer",
-  },
-  {
-    message: "テスト注文のため",
-    key: "placedTest",
-  },
-];
-
-export const acceptedCancelReasons = [
-  {
-    message: "キャンセル理由を必ず選択してください",
-    key: "",
-  },
-  {
-    message: "商品不良",
-    key: "acceptedBadCondition",
-  },
-  {
-    message: "発注漏れ",
-    key: "acceptedNoOrder",
-  },
-  {
-    message: "商品未納",
-    key: "acceptedNoStock",
-  },
-  {
-    message: "お客様申し出",
-    key: "acceptedByCustomer",
-  },
-  {
-    message: "テスト注文のため",
-    key: "acceptedTest",
-  },
-];
-
 export const partners = [
   {
     id: "singularitysociety",

--- a/src/config/constant.ts
+++ b/src/config/constant.ts
@@ -58,14 +58,6 @@ export const next_transitions: { [key: number]: number } = {
   [order_status.transaction_complete]: order_status.transaction_hide,
 };
 
-export const order_error = {
-  validation_error: 100,
-  order_canceled_by_customer: 200,
-  payment_error: 300,
-  order_canceled_by_restaurant: 400,
-  unknow_error: 900,
-};
-
 export const timeEventMapping = {
   order_placed: "orderPlacedAt",
   order_accepted: "orderAcceptedAt",

--- a/src/config/constant.ts
+++ b/src/config/constant.ts
@@ -58,6 +58,14 @@ export const next_transitions: { [key: number]: number } = {
   [order_status.transaction_complete]: order_status.transaction_hide,
 };
 
+export const order_error = {
+  validation_error: 100,
+  order_canceled_by_customer: 200,
+  payment_error: 300,
+  order_canceled_by_restaurant: 400,
+  unknow_error: 900,
+};
+
 export const timeEventMapping = {
   order_placed: "orderPlacedAt",
   order_accepted: "orderAcceptedAt",


### PR DESCRIPTION
## Summary

- `src/config/constant.ts` から `placedCancelReasons` / `acceptedCancelReasons` (53 行) を削除
- 参照ゼロ確認済み

## Items to Confirm / Review

- 検索コマンド: \`grep -rn 'placedCancelReasons\|acceptedCancelReasons' src/ functions/src/\` で `src/config/constant.ts` の宣言と `functions/src/common/` の自動コピー以外参照なし
- `functions/src/common/constant.ts` は `src/` からの自動コピー先（CLAUDE.md 参照）、次回 deploy 時に同期
- `yarn build` 通過済み
- 当初 `order_error` も削除対象に入れていたが、ユーザー判断により残置（revert 済み）

## User Prompts

> X-HIGH-1  placedCancelReasons / acceptedCancelReasonsはもう使ってなければ削除。
> ほか、constantで未利用があれば削除。

## Implementation

`src/config/constant.ts` から `placedCancelReasons` / `acceptedCancelReasons` の 2 定数を削除。

Plan: `plans/fix-X-HIGH-1-remove-unused-cancel-reasons.md`

Closes #1704