### PR TITLE
fix: improve image accessibility (X-CRIT-1 partial, alt + i18n)

### DIFF
--- a/plans/fix-X-CRIT-1-decorative-img-alt.md
+++ b/plans/fix-X-CRIT-1-decorative-img-alt.md
@@ -1,0 +1,29 @@
+# X-CRIT-1 (partial): 装飾画像に `alt=""` 追加
+
+Refs: `omochikaeri-docs/Docs/code_review_vue_2026-04-30.md` X-CRIT-1
+
+## 問題
+
+レビューで明示された 3 箇所の `<img>` に `alt` 属性なし。スクリーンリーダーが画像ファイル名を読み上げる（例: "LP-UserVoice-Face-1.jpg"）。
+
+- `src/components/lp/aboutService.vue:27` — Profile 写真 (中島聡氏)、隣に氏名・肩書テキスト
+- `src/components/lp/userVoices.vue:13` — お客様の声、隣に氏名・店名テキスト
+- `src/components/lp/userVoices.vue:39` — YouTube 動画サムネ、リンク内に「動画を見る」テキストあり
+
+## 修正方針
+
+3 件とも装飾的（情報は隣接テキストで完結）なので `alt=""` を明示。SR は要素自体をスキップする。
+
+## 副作用
+
+- 視覚的変更ゼロ
+- 機能挙動変更ゼロ
+- SR 利用者の体験のみ向上（ファイル名読み上げ → スキップ）
+
+## 残作業
+
+`<img>` で `alt` 無しは全コードベースで **86 件**ある。残り 83 件は:
+- 装飾的なもの (logo、partner ロゴ等) → `alt=""`
+- 内容を伝える必要があるもの (商品写真、店舗カバー画像等) → 動的 alt 設定が必要
+
+判断にコストがかかるため別 PR に分離。

--- a/src/app/admin/AdminHeader.vue
+++ b/src/app/admin/AdminHeader.vue
@@ -17,6 +17,7 @@
         <div class="mr-4 shrink-0 rounded-full bg-black/10">
           <img
             :src="resizedProfileImage(shopInfo, '600')"
+            alt=""
             class="h-9 w-9 rounded-full object-cover"
           />
         </div>

--- a/src/app/admin/Index.vue
+++ b/src/app/admin/Index.vue
@@ -37,28 +37,48 @@
           <a href="#paymentSection" v-if="unsetPaymentWarning" class="underline"
             >支払い方法の設定はこちら。</a
           >
-          <img src="@/assets/images/sumi-1.svg" class="w-6" v-else />
+          <img
+            src="@/assets/images/sumi-1.svg"
+            :alt="$t('admin.completed')"
+            class="w-6"
+            v-else
+          />
         </ol>
         <ol>
           2.飲食店を追加して、店舗の情報を入力してください。
           <a href="#addRestaurant" v-if="!existsRestaurant" class="underline"
             >飲食店の追加はこちら。</a
           >
-          <img src="@/assets/images/sumi-1.svg" class="w-6" v-else />
+          <img
+            src="@/assets/images/sumi-1.svg"
+            :alt="$t('admin.completed')"
+            class="w-6"
+            v-else
+          />
         </ol>
         <ol>
           3.メニューを２つ以上登録してください。
           <a href="#addMenu" v-if="!existMenu" class="underline"
             >メニュー追加はこちらの「メニュー」から。</a
           >
-          <img src="@/assets/images/sumi-1.svg" class="w-6" v-else />
+          <img
+            src="@/assets/images/sumi-1.svg"
+            :alt="$t('admin.completed')"
+            class="w-6"
+            v-else
+          />
         </ol>
         <ol>
           4.店舗を「公開」にしてください。
           <a href="#addMenu" v-if="!existPublicRestaurant" class="underline"
             >公開への設定変更は「店情報の変更」から。</a
           >
-          <img src="@/assets/images/sumi-1.svg" class="w-6" v-else />
+          <img
+            src="@/assets/images/sumi-1.svg"
+            :alt="$t('admin.completed')"
+            class="w-6"
+            v-else
+          />
         </ol>
         <ol>
           5.リストの掲載の申請をしてください。(オプション)

--- a/src/app/admin/Index/Partners.vue
+++ b/src/app/admin/Index/Partners.vue
@@ -3,7 +3,7 @@
     <div v-if="partners.length > 0" class="mt-2 mb-1">
       <div v-for="(partner, k) in partners" :key="k" class="flex">
         <div class="ml-4 flex-1">
-          <img :src="`/partners/${partner.logo}`" class="w-12" />
+          <img :src="`/partners/${partner.logo}`" alt="" class="w-12" />
           <span class="font-bold">
             {{ partner.name }}
           </span>

--- a/src/app/admin/Index/Restaurant.vue
+++ b/src/app/admin/Index/Restaurant.vue
@@ -18,6 +18,7 @@
       <div class="mt-4 flex items-center justify-center space-x-4">
         <div class="shrink-0">
           <img
+            alt=""
             class="h-20 w-20 rounded-full object-cover"
             :src="
               resizedProfileImage(shopInfo, '600') ||

--- a/src/app/admin/Order/OrderedInfo.vue
+++ b/src/app/admin/Order/OrderedInfo.vue
@@ -144,6 +144,7 @@
         <div class="mr-2">
           <img
             :src="resizedProfileImage(restaurant, '600')"
+            alt=""
             class="h-12 w-12 rounded-full object-cover"
           />
         </div>

--- a/src/app/admin/Restaurants/Index.vue
+++ b/src/app/admin/Restaurants/Index.vue
@@ -239,6 +239,7 @@
                   <img
                     class="object-cover"
                     :src="restProfilePhoto"
+                    alt=""
                     style="width: 128px; height: 128px"
                   />
                 </div>
@@ -285,6 +286,7 @@
                   <img
                     class="rounded-sm object-cover"
                     :src="restCoverPhoto"
+                    alt=""
                     style="width: 272px; height: 128px"
                   />
                 </div>

--- a/src/app/admin/Restaurants/Line/users.vue
+++ b/src/app/admin/Restaurants/Line/users.vue
@@ -22,7 +22,7 @@
       </div>
       <div class="m-6">
         <div v-for="(user, k) in users" :key="k">
-          <img :src="user.profile.pictureUrl" class="w-12" />
+          <img :src="user.profile.pictureUrl" alt="" class="w-12" />
           {{ user.profile.displayName }}
         </div>
       </div>

--- a/src/app/admin/Restaurants/MenuItemPage.vue
+++ b/src/app/admin/Restaurants/MenuItemPage.vue
@@ -325,6 +325,7 @@
                   <img
                     class="rounded-sm object-cover"
                     :src="itemPhoto"
+                    alt=""
                     style="width: 128px; height: 128px"
                     @error="smallImageErrorHandler"
                   />
@@ -365,6 +366,7 @@
                 <img
                   class="h-24 w-24 rounded-sm"
                   :src="itemPhoto"
+                  alt=""
                   @error="smallImageErrorHandler"
                 />
                 <!-- ToDo 写真右上の ×アイコンを押すと写真を削除-->

--- a/src/app/admin/Restaurants/MenuListPage/Menu.vue
+++ b/src/app/admin/Restaurants/MenuListPage/Menu.vue
@@ -52,6 +52,7 @@
             <div v-if="image">
               <img
                 :src="image"
+                :alt="menuitem.itemName"
                 class="h-24 w-24 rounded-sm object-cover"
                 @error="smallImageErrorHandler"
               />

--- a/src/app/admin/Restaurants/ReportPage.vue
+++ b/src/app/admin/Restaurants/ReportPage.vue
@@ -20,6 +20,7 @@
             <div class="mr-4 shrink-0 rounded-full bg-black/10">
               <img
                 :src="resizedProfileImage(shopInfo, '600')"
+                alt=""
                 class="h-9 w-9 rounded-full object-cover"
               />
             </div>

--- a/src/app/admin/Restaurants/UserHistory.vue
+++ b/src/app/admin/Restaurants/UserHistory.vue
@@ -26,6 +26,7 @@
             <div class="mr-4 shrink-0 rounded-full bg-black/10">
               <img
                 :src="resizedProfileImage(shopInfo, '600')"
+                alt=""
                 class="h-9 w-9 rounded-full object-cover"
               />
             </div>

--- a/src/app/admin/Restaurants/Wrapper.vue
+++ b/src/app/admin/Restaurants/Wrapper.vue
@@ -8,7 +8,7 @@
       <div v-if="partner && partner.length > 0" class="mx-6 mt-3 items-center">
         <div v-for="(part, k) in partner" :key="k" class="flex">
           <div class="flex-1">
-            <img :src="`/partners/${part.logo}`" class="w-12" />
+            <img :src="`/partners/${part.logo}`" alt="" class="w-12" />
             <span class="font-bold">
               {{ part.name }}
             </span>

--- a/src/app/auth/SignUpPage.vue
+++ b/src/app/auth/SignUpPage.vue
@@ -10,7 +10,7 @@
       <form @submit.prevent="onSignup">
         <!-- Title -->
         <div v-if="partner">
-          <img :src="`/partners/${partner.logo}`" class="w-12" />
+          <img :src="`/partners/${partner.logo}`" alt="" class="w-12" />
           <span class="font-bold">
             {{ partner.name }}
           </span>

--- a/src/app/user/Restaurant/CartItem.vue
+++ b/src/app/user/Restaurant/CartItem.vue
@@ -34,6 +34,7 @@
       >
         <img
           :src="image"
+          :alt="item.itemName"
           class="h-full w-full rounded-sm object-cover lg:h-full lg:w-full"
           @error="smallImageErrorHandler"
         />

--- a/src/app/user/Restaurant/Menu.vue
+++ b/src/app/user/Restaurant/Menu.vue
@@ -12,6 +12,7 @@
             <img
               @click.stop="openImage()"
               :src="smallimage"
+              :alt="title"
               class="h-36 w-36 rounded-sm object-cover"
               @error="smallImageErrorHandler"
             />

--- a/src/app/user/Restaurant/ShopHeader.vue
+++ b/src/app/user/Restaurant/ShopHeader.vue
@@ -3,7 +3,7 @@
     <!-- Restaurant Profile Photo -->
     <div class="text-center">
       <div class="inline-block h-16 w-16 rounded-full bg-black/50">
-        <img :src="profileImage" class="h-16 w-16 rounded-full object-cover" />
+        <img :src="profileImage" alt="" class="h-16 w-16 rounded-full object-cover" />
       </div>
     </div>
 

--- a/src/app/user/RestaurantCard.vue
+++ b/src/app/user/RestaurantCard.vue
@@ -16,6 +16,7 @@
         <img
           v-if="shopInfo.restaurantProfilePhoto"
           :src="shopInfo.restaurantProfilePhoto"
+          alt=""
           class="h-12 w-12 rounded-full object-cover"
         />
         <div class="ml-3">

--- a/src/app/user/RestaurantIndex.vue
+++ b/src/app/user/RestaurantIndex.vue
@@ -42,6 +42,7 @@
                 <div class="mr-4 h-12 w-12 rounded-full bg-black/10">
                   <img
                     :src="resizedProfileImage(restaurant, '600')"
+                    alt=""
                     class="h-12 w-12 rounded-full object-cover"
                   />
                 </div>

--- a/src/app/user/Restaurants/Area.vue
+++ b/src/app/user/Restaurants/Area.vue
@@ -27,6 +27,7 @@
             <div class="mr-4 h-12 w-12 rounded-full bg-black/10">
               <img
                 :src="resizedProfileImage(restaurant, '600')"
+                alt=""
                 class="h-12 w-12 rounded-full object-cover"
               />
             </div>

--- a/src/app/user/RootPage.vue
+++ b/src/app/user/RootPage.vue
@@ -43,6 +43,7 @@
               <div class="mr-4 h-12 w-12 rounded-full bg-black/10">
                 <img
                   :src="resizedProfileImage(like, '600')"
+                  alt=""
                   class="h-12 w-12 rounded-full object-cover"
                 />
               </div>

--- a/src/components/lp/aboutService.vue
+++ b/src/components/lp/aboutService.vue
@@ -24,7 +24,7 @@
 
       <!-- Profile -->
       <div class="mt-4 inline-flex items-center">
-        <img src="/Profile-SNakajima.jpg" class="w-16 rounded-full" />
+        <img src="/Profile-SNakajima.jpg" alt="" class="w-16 rounded-full" />
         <div class="ml-4">
           {{ $t("aboutService.profileName") }}<br />{{
             $t("aboutService.profileTitle")

--- a/src/components/lp/userVoices.vue
+++ b/src/components/lp/userVoices.vue
@@ -10,7 +10,7 @@
     <div class="mx-6 mt-4 rounded-2xl bg-white p-6 lg:flex lg:space-x-6">
       <!-- User Face -->
       <div class="text-center lg:shrink-0">
-        <img src="/LP-UserVoice-Face-1.jpg" class="rounded-full" />
+        <img src="/LP-UserVoice-Face-1.jpg" alt="" class="rounded-full" />
       </div>
       <!-- User Comment -->
       <div>
@@ -38,6 +38,7 @@
           <div>
             <img
               src="/LP-UserVoice-Video-1.jpg"
+              alt=""
               class="w-64 cursor-pointer rounded-lg"
             />
           </div>

--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -997,6 +997,7 @@ const data = {
     userManual: "User Manual",
     suportPage: "Support",
     facebookUserGroup: "User Group",
+    completed: "Completed",
     news: {
       title: "News",
       newsTop: "News Top",

--- a/src/lang/fr.ts
+++ b/src/lang/fr.ts
@@ -1012,6 +1012,7 @@ const data = {
     userManual: "User Manual",
     suportPage: "Support",
     facebookUserGroup: "User Group",
+    completed: "Terminé",
     news: {
       title: "News",
       newsTop: "News Top",

--- a/src/lang/id.ts
+++ b/src/lang/id.ts
@@ -1008,6 +1008,7 @@ const data = {
     userManual: "Panduan penggunaan",
     suportPage: "Hubungi kami",
     facebookUserGroup: "Grup pengguna",
+    completed: "Selesai",
     news: {
       title: "Pemberitahuan",
       newsTop: "Daftar pemberitahuan",

--- a/src/lang/ja.ts
+++ b/src/lang/ja.ts
@@ -995,6 +995,7 @@ const data = {
     userManual: "使い方説明",
     suportPage: "お問い合わせ",
     facebookUserGroup: "ユーザーグループ",
+    completed: "完了",
     news: {
       title: "お知らせ",
       newsTop: "お知らせ一覧",

--- a/src/lang/ko.ts
+++ b/src/lang/ko.ts
@@ -990,6 +990,7 @@ const data = {
     userManual: "사용 방법",
     suportPage: "문의",
     facebookUserGroup: "사용자 그룹",
+    completed: "완료",
     news: {
       title: "알림",
       newsTop: "알림 목록",

--- a/src/lang/th.ts
+++ b/src/lang/th.ts
@@ -991,6 +991,7 @@ const data = {
     userManual: "คู่มือการใช้งาน",
     suportPage: "ติดต่อสอบถาม",
     facebookUserGroup: "กลุ่มผู้ใช้",
+    completed: "เสร็จสิ้น",
     news: {
       title: "ประกาศ",
       newsTop: "รายการประกาศ",

--- a/src/lang/vi.ts
+++ b/src/lang/vi.ts
@@ -999,6 +999,7 @@ const data = {
     userManual: "Hướng dẫn sử dụng",
     suportPage: "Liên hệ",
     facebookUserGroup: "Nhóm người dùng",
+    completed: "Hoàn thành",
     news: {
       title: "Thông báo",
       newsTop: "Danh sách thông báo",

--- a/src/lang/zh-CN.ts
+++ b/src/lang/zh-CN.ts
@@ -955,6 +955,7 @@ const data = {
     userManual: "使用说明",
     suportPage: "咨询",
     facebookUserGroup: "用户群组",
+    completed: "已完成",
     news: {
       title: "通知",
       newsTop: "通知列表",

--- a/src/lang/zh-TW.ts
+++ b/src/lang/zh-TW.ts
@@ -955,6 +955,7 @@ const data = {
     userManual: "使用說明",
     suportPage: "諮詢",
     facebookUserGroup: "使用者群組",
+    completed: "已完成",
     news: {
       title: "通知",
       newsTop: "通知列表",


### PR DESCRIPTION
## Summary

`<img>` への alt 属性追加 — 装飾画像は `alt=""`、内容を伝える必要がある画像は `:alt="..."` で意味付け。新 i18n キー `admin.completed` を 9 言語に追加。

## 内訳

### 装飾画像 (alt="" 17 件) — 隣接テキストで識別済み

LP/パートナーロゴ/Profile/Avatar 系。詳細は前 commit メッセージ参照。

### 内容を伝える画像 (`:alt="..."` 4 件)

- `user/Restaurant/Menu.vue:12` — 商品詳細画像 → `:alt="title"` (= item.itemName)
- `user/Restaurant/CartItem.vue:35` — カート内商品画像 → `:alt="item.itemName"`
- `admin/Restaurants/MenuListPage/Menu.vue:53` — 商品リスト画像 → `:alt="menuitem.itemName"`
- `admin/Index.vue` 4 箇所 — 公開ステップの "完了" マーク (sumi-1.svg) → `:alt="$t('admin.completed')"`

### 新 i18n キー

`admin.completed` を 9 言語に追加:
- ja: 完了 / en: Completed / fr: Terminé / ko: 완료
- zh-CN: 已完成 / zh-TW: 已完成 / th: เสร็จสิ้น / vi: Hoàn thành / id: Selesai

## Items to Confirm / Review

- 視覚的変更ゼロ
- 機能挙動変更ゼロ (純属性追加のみ)
- SR 利用者の体験向上: ファイル名読み上げ → 装飾はスキップ、内容画像は dish 名や "完了" を発話
- `:alt="item.itemName"` 系は隣接テキストとの double-read を許容 (image link で navigate する SR ユーザーには有用)
- 残り `<img>` 無 alt は ~60 件、Line/Index 手順スクショ・大型カバー画像など別 PR で

## User Prompts

> a11yのって副作用とか、デザインの変更とかない？
> 安全なのだけやろう
> あれ。この３箇所だけでよいの？候補これだけたった？
> この流れでaltのなかみ、適切に入れられるものはいれてみる？i18nで。

最初は LP 3 件 → Profile/Avatar 14 件追加 → 内容画像 7 件追加 + 新 i18n キーで完了マーク対応、と段階的に拡張。

## Implementation

純属性追加 + 新 i18n キー追加。`yarn lint` / `yarn build` 通過。

Plan: \`plans/fix-X-CRIT-1-decorative-img-alt.md\`