### PR TITLE
chore: elevate eslint warn rules to error

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -64,7 +64,7 @@ export default [
       "vue/v-bind-style": "error",
       "vue/require-default-prop": "off",
       "vue/require-prop-types": "error",
-      "vue/no-mutating-props": "warn",
+      "vue/no-mutating-props": "error",
       "vue/no-undef-properties": "error",
       "no-undef": "error",
       "no-useless-assignment": "error",
@@ -79,7 +79,7 @@ export default [
       
       // "no-type-assertion/no-type-assertion": "warn",
       "no-console": "off",
-      "no-debugger": process.env.NODE_ENV === "production" ? "warn" : "off",
+      "no-debugger": process.env.NODE_ENV === "production" ? "error" : "off",
 
       "vue/require-explicit-emits": "error",
       "vue/no-unused-properties": "error",


### PR DESCRIPTION
## Summary

`eslint.config.mjs` で残っていた `warn` レベルのルール 2 件を `error` に昇格。

- `vue/no-mutating-props`: warn → error (PR #1624 で違反ゼロ化済み)
- `no-debugger` (production): warn → error (production ビルドに `debugger` を残さない)

## Items to Confirm / Review

- 現コードベースは両ルールで違反ゼロ確認済み (`yarn lint` 通過)
- `no-debugger` の dev (`process.env.NODE_ENV !== "production"`) は引き続き `off` (デバッグ作業中の利便性維持)

## User Prompt

> 以前、propsで渡したものを、渡した先で更新していたコードがあったきがしたんだけどもうない？
> はい。ほかも全部warnは更新

PR #1624 で prop ミューテーションは解消済み。再発防止と他の warn 状態の `no-debugger` も含めて error に昇格。

## Summary by Sourcery

Elevate remaining eslint warn-level rules to errors to enforce stricter linting in production.

Enhancements:
- Update vue/no-mutating-props rule from warn to error in the shared ESLint configuration.
- Tighten no-debugger rule to be treated as an error in production builds while remaining disabled in non-production environments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development linting configuration to strengthen code quality checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->