### PR TITLE
fix: DateTimePicker month header reactivity and past-date grayout

### DIFF
--- a/src/app/admin/Restaurants/Discount/Discount.vue
+++ b/src/app/admin/Restaurants/Discount/Discount.vue
@@ -113,7 +113,7 @@
           ~
           <DateTimePicker
             v-model="termToDate"
-            :min-date="new Date()"
+            :min-date="termFromDate"
             :placeholder="$t('shopInfo.temporaryClosureSelect')"
             class="ml-4 lg:w-96"
           />

--- a/src/components/DateTimePicker.vue
+++ b/src/components/DateTimePicker.vue
@@ -19,11 +19,19 @@
     >
       <div class="w-full max-w-xs rounded-lg bg-white p-4 shadow-lg">
         <div class="mb-4 flex items-center justify-between">
-          <button @click="prevMonth" class="rounded-full p-2 hover:bg-gray-100">
+          <button
+            @click="prevMonth"
+            :disabled="!canPrevMonth"
+            class="rounded-full p-2 hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-30 disabled:hover:bg-transparent"
+          >
             &lt;
           </button>
           <div class="text-lg font-semibold">{{ monthName }} {{ year }}</div>
-          <button @click="nextMonth" class="rounded-full p-2 hover:bg-gray-100">
+          <button
+            @click="nextMonth"
+            :disabled="!canNextMonth"
+            class="rounded-full p-2 hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-30 disabled:hover:bg-transparent"
+          >
             &gt;
           </button>
         </div>
@@ -40,10 +48,16 @@
             :key="index"
             @click="selectDate(day)"
             :class="[
-              'flex h-8 w-8 cursor-pointer items-center justify-center rounded-full',
-              { 'bg-blue-500 text-white hover:bg-blue-600': isSelected(day) },
-              { 'text-gray-400': !isSameMonth(day) },
-              { 'hover:bg-gray-200': !isSelected(day) },
+              'flex h-8 w-8 items-center justify-center rounded-full',
+              isDisabled(day)
+                ? 'cursor-not-allowed text-gray-300'
+                : 'cursor-pointer',
+              {
+                'bg-blue-500 text-white hover:bg-blue-600':
+                  isSelected(day) && !isDisabled(day),
+              },
+              { 'text-gray-400': !isSameMonth(day) && !isDisabled(day) },
+              { 'hover:bg-gray-200': !isSelected(day) && !isDisabled(day) },
               { 'ring-2 ring-blue-500': isToday(day) && !isSelected(day) },
             ]"
           >
@@ -119,8 +133,8 @@ const formattedDate = computed(() => {
     : "";
 });
 
-const year = currentMonth.value.year();
-const monthName = currentMonth.value.format("MMMM");
+const year = computed(() => currentMonth.value.year());
+const monthName = computed(() => currentMonth.value.format("MMMM"));
 
 const daysOfWeek = [
   "week.shortest.sunday",
@@ -158,11 +172,16 @@ const isSameMonth = (day: Date) => {
   return moment(day).isSame(currentMonth.value, "month");
 };
 
-const selectDate = (day: Date) => {
-  // Add validation if min/max date props are implemented
-  if (props.minDate && day < props.minDate) return;
-  if (props.maxDate && day > props.maxDate) return;
+const isDisabled = (day: Date) => {
+  if (props.minDate && moment(day).isBefore(moment(props.minDate), "day"))
+    return true;
+  if (props.maxDate && moment(day).isAfter(moment(props.maxDate), "day"))
+    return true;
+  return false;
+};
 
+const selectDate = (day: Date) => {
+  if (isDisabled(day)) return;
   const newDate = moment(day).hour(hours.value).minute(minutes.value).toDate();
   emit("update:modelValue", newDate);
 };
@@ -185,11 +204,31 @@ watch([hours, minutes], () => {
   }
 });
 
+const canPrevMonth = computed(() => {
+  if (!props.minDate) return true;
+  return currentMonth.value
+    .clone()
+    .subtract(1, "month")
+    .endOf("month")
+    .isSameOrAfter(moment(props.minDate).startOf("day"));
+});
+
+const canNextMonth = computed(() => {
+  if (!props.maxDate) return true;
+  return currentMonth.value
+    .clone()
+    .add(1, "month")
+    .startOf("month")
+    .isSameOrBefore(moment(props.maxDate).endOf("day"));
+});
+
 const prevMonth = () => {
+  if (!canPrevMonth.value) return;
   currentMonth.value = currentMonth.value.clone().subtract(1, "month");
 };
 
 const nextMonth = () => {
+  if (!canNextMonth.value) return;
   currentMonth.value = currentMonth.value.clone().add(1, "month");
 };
 

--- a/src/components/DateTimePicker.vue
+++ b/src/components/DateTimePicker.vue
@@ -40,16 +40,11 @@
             :key="index"
             @click="selectDate(day)"
             :class="[
-              'flex h-8 w-8 items-center justify-center rounded-full',
-              isDisabled(day)
-                ? 'cursor-not-allowed text-gray-300'
-                : 'cursor-pointer',
-              {
-                'bg-blue-500 text-white hover:bg-blue-600':
-                  isSelected(day) && !isDisabled(day),
-              },
+              'flex h-8 w-8 cursor-pointer items-center justify-center rounded-full',
+              { 'text-gray-300': isDisabled(day) && !isSelected(day) },
+              { 'bg-blue-500 text-white hover:bg-blue-600': isSelected(day) },
               { 'text-gray-400': !isSameMonth(day) && !isDisabled(day) },
-              { 'hover:bg-gray-200': !isSelected(day) && !isDisabled(day) },
+              { 'hover:bg-gray-200': !isSelected(day) },
               { 'ring-2 ring-blue-500': isToday(day) && !isSelected(day) },
             ]"
           >
@@ -173,7 +168,6 @@ const isDisabled = (day: Date) => {
 };
 
 const selectDate = (day: Date) => {
-  if (isDisabled(day)) return;
   const newDate = moment(day).hour(hours.value).minute(minutes.value).toDate();
   emit("update:modelValue", newDate);
 };

--- a/src/components/DateTimePicker.vue
+++ b/src/components/DateTimePicker.vue
@@ -19,19 +19,11 @@
     >
       <div class="w-full max-w-xs rounded-lg bg-white p-4 shadow-lg">
         <div class="mb-4 flex items-center justify-between">
-          <button
-            @click="prevMonth"
-            :disabled="!canPrevMonth"
-            class="rounded-full p-2 hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-30 disabled:hover:bg-transparent"
-          >
+          <button @click="prevMonth" class="rounded-full p-2 hover:bg-gray-100">
             &lt;
           </button>
           <div class="text-lg font-semibold">{{ monthName }} {{ year }}</div>
-          <button
-            @click="nextMonth"
-            :disabled="!canNextMonth"
-            class="rounded-full p-2 hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-30 disabled:hover:bg-transparent"
-          >
+          <button @click="nextMonth" class="rounded-full p-2 hover:bg-gray-100">
             &gt;
           </button>
         </div>
@@ -204,31 +196,11 @@ watch([hours, minutes], () => {
   }
 });
 
-const canPrevMonth = computed(() => {
-  if (!props.minDate) return true;
-  return currentMonth.value
-    .clone()
-    .subtract(1, "month")
-    .endOf("month")
-    .isSameOrAfter(moment(props.minDate).startOf("day"));
-});
-
-const canNextMonth = computed(() => {
-  if (!props.maxDate) return true;
-  return currentMonth.value
-    .clone()
-    .add(1, "month")
-    .startOf("month")
-    .isSameOrBefore(moment(props.maxDate).endOf("day"));
-});
-
 const prevMonth = () => {
-  if (!canPrevMonth.value) return;
   currentMonth.value = currentMonth.value.clone().subtract(1, "month");
 };
 
 const nextMonth = () => {
-  if (!canNextMonth.value) return;
   currentMonth.value = currentMonth.value.clone().add(1, "month");
 };
 


### PR DESCRIPTION
## Summary
値引き編集画面の DateTimePicker でヘッダーの月・年表示が動かない bug を修正し、開始日 / 終了日のグレーアウト UI を追加した。

- 対象: `src/components/DateTimePicker.vue` 本体修正と、`src/app/admin/Restaurants/Discount/Discount.vue` (終了日の `min-date` を開始日に紐付け)
- 除外: カレンダー a11y 全面改修 / moment locale 連携 / コンポーネントテスト基盤整備 / `DatePicker.vue` との統合 (いずれも pre-existing、別 PR 推奨)
- 起点: 月送りボタン `<` `>` を押してもヘッダー表示が `2026 May` のまま固定する報告

from
<img width="392" height="460" alt="image" src="https://github.com/user-attachments/assets/892b8fc2-415f-4e8e-a4ef-ab67ede9f583" />

to
<img width="366" height="463" alt="image" src="https://github.com/user-attachments/assets/2271bb1d-b1a9-4616-b41f-c3162057157d" />


## Items to Confirm / Review
- `year` / `monthName` を setup-time const → `computed` 化した reactivity 修正
- 過去日の判定を `Date <` から `moment().isBefore(_, "day")` (日単位) に変更したため、`new Date()` を minDate に渡しても「今日」が選択可能になる挙動の意図確認
- 終了日ピッカーの `min-date` を開始日に紐付けたが、開始日未選択時はグレーアウトなしのフォールバックでよいか
- グレーアウトは視覚的注意のみで、クリック選択は許可している (`Discount.vue:save()` 側に過去日ブロックはない)

## User Prompt
- 値引き編集画面で月送りボタンを押してもヘッダーの年月表示が変わらない不具合の修正依頼
- 過去日のグレーアウト表示・「今日」を選択可能にする・終了日ピッカーのグレーアウト基準を開始日に揃える、の UX 改善依頼

## Implementation
1. `src/components/DateTimePicker.vue`
   - `year` / `monthName` を `computed` 化してヘッダーを reactive に
   - `isDisabled(day)` ヘルパー (props.minDate / maxDate を日単位で比較)
   - day cell に `text-gray-300` のグレーアウト。`selectDate` 側にガードは入れず選択は許可
2. `src/app/admin/Restaurants/Discount/Discount.vue`
   - 終了日ピッカーの `:min-date` を `new Date()` → `termFromDate` に変更

## Review
`/codex-cross-review` を 4 ラウンド実施して両者で convergence。iteration 1 で挙がった a11y / locale / テスト基盤 / `DatePicker.vue` 統合は本 PR の scope を超えるため defer 判定。

## Test Plan
- [ ] 管理者で値引き編集画面を開く
- [ ] 開始日 / 終了日カレンダーで `<` `>` ボタンを押し、ヘッダーの月・年が追従することを確認
- [ ] 開始日: 今日より前の日付がグレーアウト
- [ ] 終了日: 開始日より前の日付がグレーアウト
- [ ] 開始日未選択時の終了日: グレーアウトなし
- [ ] グレーアウトされた日付も選択でき、選択状態が反映される

---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed date validation in discount settings to prevent end dates from being set earlier than start dates.

* **UI Improvements**
  * Enhanced date picker component to visually indicate disabled dates outside the allowed range, providing clearer feedback on selectable dates.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Nakajima-Foundation/ownplate/pull/1724?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->