### PR TITLE
fix: auto-activate JCB on account.updated webhook

### DIFF
--- a/functions/src/lib/stripeLog.ts
+++ b/functions/src/lib/stripeLog.ts
@@ -25,12 +25,62 @@ const accountIdToUIDs = async (db: admin.firestore.Firestore, accountId: string)
   return [];
 };
 
+// Flip the public `stripeJCB` flag for every admin tied to the given Stripe
+// connected account, after re-confirming with Stripe that JCB is really active.
+// Shared by capability.updated and account.updated handlers — Stripe sends one
+// or the other depending on the account / event, so both paths need this.
+const activateJCBIfActive = async (
+  db: admin.firestore.Firestore,
+  uids: string[],
+  accountId: string,
+) => {
+  if (uids.length === 0 || !accountId) {
+    return;
+  }
+  const stripe = utils.get_stripe_v2();
+  try {
+    const accountInfo = await stripe.accounts.retrieve(accountId);
+    const capabilities = accountInfo.capabilities as Record<string, string> | undefined;
+    if (capabilities && capabilities.jcb_payments === "active") {
+      await Promise.all(
+        uids.map(async (uid: string) => {
+          console.log("activateJCBIfActive: updating", uid);
+          await db.doc(`admins/${uid}/public/payment`).update({
+            stripeJCB: true,
+          });
+        }),
+      );
+    } else {
+      console.error("activateJCBIfActive: jcb_payments not active in retrieved account", capabilities);
+    }
+  } catch (error) {
+    console.error("activateJCBIfActive: failed to retrieve account info", accountId, error);
+  }
+};
+
 export const account_updated = async (db: admin.firestore.Firestore, event: Stripe.Event) => {
   const {
-    data: { object },
+    data: { object, previous_attributes },
   } = event;
   const id = ("id" in object ? object.id : "") as string;
   const uids = await accountIdToUIDs(db, id ?? "");
+
+  // Stripe fires either capability.updated or account.updated when JCB flips
+  // to "active". For Standard connect accounts (this codebase), it often comes
+  // as account.updated with the change reflected in previous_attributes. Only
+  // act on a real transition: `jcb_payments` must be present in
+  // previous_attributes.capabilities AND currently "active".
+  const previousCapabilities =
+    (previous_attributes as { capabilities?: Record<string, string> } | undefined)?.capabilities;
+  const currentCapabilities =
+    ("capabilities" in object ? (object.capabilities as Record<string, string> | undefined) : undefined);
+  if (
+    previousCapabilities &&
+    "jcb_payments" in previousCapabilities &&
+    currentCapabilities?.jcb_payments === "active"
+  ) {
+    await activateJCBIfActive(db, uids, id);
+  }
 
   return await callbackAdminLog(db, uids, stripeActions.account_updated, event);
 };
@@ -44,27 +94,8 @@ export const capability_updated = async (db: admin.firestore.Firestore, event: S
   const id = ("id" in object ? object.id : "") as string;
   const uids = await accountIdToUIDs(db, account);
 
-  const stripe = utils.get_stripe_v2();
   if (status === "active" && id === "jcb_payments") {
-    try {
-      // Check if JCB payments are really active (paranoia)
-      const accountInfo = await stripe.accounts.retrieve(account);
-      const capabilities = accountInfo.capabilities as Record<string, string> | undefined;
-      if (capabilities && capabilities.jcb_payments === "active") {
-        await Promise.all(
-          uids.map(async (uid: string) => {
-            console.log("capability_updated: updating", uid, accountInfo);
-            await db.doc(`admins/${uid}/public/payment`).update({
-              stripeJCB: true,
-            });
-          }),
-        );
-      } else {
-        console.error("capability_updated: no capabilities", capabilities);
-      }
-    } catch (__error) {
-      console.error("capability_updated: failed to retrieve account info", account);
-    }
+    await activateJCBIfActive(db, uids, account);
   }
 
   // log


### PR DESCRIPTION
## Summary

Stripe Connect Standard アカウントで JCB が active になると、Stripe は \`account.updated\` event を送ってくる (実例: 2026-05-26 02:51 の \`evt_1TbDtqD4Kprdkefxblc0VBOt\` を /s/callbacks で確認)。が、既存の自動同期コードは \`capability.updated\` event しか見ていないため、Firestore の \`stripeJCB\` フラグが立たず、ユーザー決済画面で「JCB が使えません」と表示され続ける問題があった。

\`account_updated\` ハンドラに \`previous_attributes.capabilities.jcb_payments\` の遷移検知を追加し、\`active\` になっていれば Firestore フラグを自動 ON にする。

## Items to Confirm / Review

- 既存の \`capability_updated\` 内の activation ロジックを \`activateJCBIfActive\` ヘルパに抽出 (動作変更なし)
- \`account_updated\` 内で transition 検知 → 同ヘルパ呼び出し
- 検知条件: \`previous_attributes.capabilities.jcb_payments\` が存在 (capability が変化) AND \`object.capabilities.jcb_payments === "active"\` (現状 active)
  - 他要因 (bank account 変更等) の \`account.updated\` event では \`previous_attributes.capabilities\` 自体が無いか \`jcb_payments\` キーが入っていない → スキップ
- 二重防御: ヘルパ内で \`stripe.accounts.retrieve()\` で再確認してから DB 更新 (元コードと同じ paranoia check)
- 既に "詰まっている" 店舗は本 PR では救えない (過去の webhook を再生しない限り):
  - super admin で /s/admins の "Activate" ボタン手動押下
  - もしくは Stripe で webhook を redelivery

## User Prompt

> https://omochikaeri.com/s/adminsでは、JCBがactiveなんだけど、
> https://omochikaeri.com/r/77XqLc2AxWhjUTVmNkiJ/order/zfm95gW8J7rGJXzjjxWz
> の決済画面では ＊このお店では、JCBカードは使えません となっている。バグ？
>
> callbackはexpressですでにうけて、
> /s/callbacks/evBBHFjQ3nMl3uxvgMaftndJbmz1/w39KRCfvs3uKHlVaw6We
> で更新も見える。これを使って対応できる？

→ 実 webhook ログ確認したところ \`account.updated\` で来ていた。原因確定。

## Implementation

\`functions/src/lib/stripeLog.ts\`:
- 新 \`activateJCBIfActive(db, uids, accountId)\` ヘルパ — 既存 \`capability_updated\` の activation block を移植
- \`capability_updated\` はヘルパ呼び出しに置換 (挙動変わらず)
- \`account_updated\` で transition 検知 → ヘルパ呼び出し

\`yarn build\` / \`yarn lint\` 通過 (functions)。

## Summary by Sourcery

Handle JCB capability activation for Stripe connected accounts on both account.updated and capability.updated webhooks to keep Firestore flags in sync with Stripe.

Bug Fixes:
- Ensure JCB availability in the user payment UI is updated when Stripe sends an account.updated event instead of capability.updated.

Enhancements:
- Extract shared JCB activation logic into a reusable helper used by both capability.updated and account.updated handlers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved JCB payment activation reliability and admin payment configuration management with enhanced error handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Nakajima-Foundation/ownplate/pull/1727?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->