### PR TITLE
chore: ignore Claude Code and local tooling artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -122,3 +122,9 @@ public/admin/docs/articles/
 
 batch/*
 **/*.sh
+
+# Claude Code / local tooling
+.claude/worktrees/
+.i18n-cache/
+.mcp.json
+.playwright-mcp/


### PR DESCRIPTION
## Summary

ローカルのツール・エディタが生成する成果物を `.gitignore` に追加する。

追加した 4 件:

- `.claude/worktrees/` — Claude Code の worktree
- `.i18n-cache/` — i18n キャッシュ
- `.mcp.json` — MCP 設定
- `.playwright-mcp/` — Playwright MCP の作業ディレクトリ

## Summary by Sourcery

Chores:
- Add Claude Code worktrees, i18n cache, MCP config, and Playwright MCP work directory artifacts to .gitignore.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository configuration files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->