### PR TITLE
fix: address review comments on map info window and storage rules

### DIFF
--- a/src/components/Map.vue
+++ b/src/components/Map.vue
@@ -89,6 +89,7 @@ export default defineComponent({
 
         const image = document.createElement("img");
         image.src = resizedProfileImage(restaurant, "600");
+        image.alt = restaurant.restaurantName;
         image.className = "h-12 w-12 rounded-full object-cover";
         anchor.appendChild(image);
 

--- a/storage.rules
+++ b/storage.rules
@@ -4,8 +4,10 @@ service firebase.storage {
   match /b/{bucket}/o {
 
     function isImageWithinLimit() {
-      return request.resource.size < 5 * 1024 * 1024
-        && request.resource.contentType.matches('image/.*');
+      // request.resource is null on delete; size/type only apply to uploads.
+      return request.resource == null
+        || (request.resource.size <= 5 * 1024 * 1024
+            && request.resource.contentType.matches('image/.*'));
     }
 
     function canEditRestaurant(restaurantId) {


### PR DESCRIPTION
## Summary

PR #1733 のマージ後に取り込めていなかった bot レビュー指摘の修正。

- **storage.rules**: `write` は delete も含むため、`isImageWithinLimit()` が delete をブロックしていた（delete 時は `request.resource` が null）。`request.resource == null` の場合は size/content-type チェックをスキップし、所有権（`canEditRestaurant`）のみで delete を許可する。あわせて上限をちょうど 5 MiB まで許可（`<` → `<=`）。
- **Map.vue**: 動的生成する info-window の img に `alt`（店舗名）を設定。

## Items to Confirm / Review

- `storage.rules` はローカルで構文検証できません。デプロイ前に Firebase Emulator または staging で検証してください（`firebase deploy --only storage` は構文エラーならデプロイを拒否します）。
- delete 時に size/type を問わないのは意図的（削除対象に resource はない）。所有権チェックは delete でも有効です。

## Verification

- `yarn build` 通過。

## Summary by Sourcery

Address post-review issues in storage rules and map info window rendering.

Bug Fixes:
- Allow image deletions in Firebase Storage rules by skipping size and content-type checks when request.resource is null while still enforcing ownership checks.
- Adjust Firebase Storage image upload rule to permit files up to exactly 5 MiB in size.

Enhancements:
- Add an alt attribute with the restaurant name to dynamically generated map info window images for better accessibility and semantics.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added descriptive alt text for restaurant marker images to improve accessibility.

* **Bug Fixes**
  * Enhanced image upload security with 5MB file size validation and content-type verification. Deletion operations now function properly without file size restrictions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->