### PR TITLE
fix: 店舗情報編集のバリデーションエラーをUIに表示（保存不可時の無表示を解消）

### DIFF
--- a/plans/fix-restaurant-validation-error-ui.md
+++ b/plans/fix-restaurant-validation-error-ui.md
@@ -1,0 +1,62 @@
+# 店舗情報編集: バリデーションエラーで保存不可なのに UI に出ない問題の修正
+
+関連 issue: https://github.com/Nakajima-Foundation/ownplate/issues/1748
+
+## 背景・課題
+
+`src/app/admin/Restaurants/Index.vue` で、`shopInfoValidator` のエラーにより保存ボタンが
+無効化(`disableSave = hasError && publicFlag`)されているのに、対応するエラー UI が無い項目があり、
+「保存できないのに画面に何も出ない」状態になる。
+
+- **完全に不可視(分類A)**: `state`(都道府県), `pickUpDaysInAdvance`(何日前予約)
+  - 特に `state` は `defaultShopInfo.state=""` かつ都道府県セレクトに空 option が無いため、
+    見た目は先頭の都道府県が選択済みに見えるのに実値は `""` のまま → 無表示で保存不可。
+- **枠/色のみでメッセージ無し(分類B)**: `pickUpMinimumCookTime`, `time`(営業時間), `restProfilePhoto`, `restCoverPhoto`
+- **validator バグ(分類C)**: `RestaurantPageUtils.ts` がメッセージキーを宙に浮いた `name`
+  (グローバル `window.name`)で組み立てており `validationError..tooMuch` のように壊れる。
+
+加えて、`TextForm.vue` は `error` を枠線色にしか使っておらず、メッセージ文言を描画していない
+(エラーメッセージを実表示しているのは PhoneEntry のみ)。`validationError` の i18n キーも
+大半が未定義。
+
+## 対応方針(本 PR で一括対応)
+
+1. **validator バグ修正**(`src/utils/admin/RestaurantPageUtils.ts`)
+   - `name` 誤用を該当フィールド名リテラルへ修正
+     (`pickUpMinimumCookTime` の `tooMuch/negative/notNumbery`, `pickUpDaysInAdvance` の `invalid`)。
+
+2. **TextForm にメッセージ表示を追加**(`src/app/admin/inputComponents/TextForm.vue`)
+   - `error.length > 0` のとき `$t(error[0])` を赤字で表示。
+   - 当コンポーネントは Index.vue 専用のため他画面に影響なし。
+
+3. **State にエラー表示＋未選択明示を追加**(`src/app/admin/inputComponents/State.vue`)
+   - `error` プロップを追加し、メッセージ表示と赤枠を追加。
+   - 未選択を示す `<option value="" disabled>` を追加(空状態を視覚化)。
+   - `Index.vue` で `:error="errors['state']"` を渡す。
+
+4. **Index.vue に残りのメッセージ表示を追加**
+   - `pickUpDaysInAdvance`(select 下), `pickUpMinimumCookTime`(input 下),
+     `time`(各 hours-input 下), `restProfilePhoto` / `restCoverPhoto`(各画像ブロック下)。
+
+5. **i18n キー追加**(`src/lang/*.ts`、es.ts はスタブのため対象外の9言語)
+   - `validationError` 配下に必要キーを全言語へ追加。
+     `restaurantName/ownerName/streetAddress/city/state` の `empty`、
+     `url/lineUrl/instagramUrl/uberEatsUrl` の `invalidUrl`、
+     `pickUpMinimumCookTime` の `tooMuch/negative/notNumbery`、
+     `pickUpDaysInAdvance` の `invalid`、
+     `restProfilePhoto/restCoverPhoto` の `empty`、
+     `oneInEmpty/validBusinessTime/noSelect`。
+   - `zip.empty` は既存を流用。
+
+## 確認観点(レビュー時)
+
+- `state` 空のとき: セレクトが未選択表示になり、メッセージ＋赤枠が出て、公開保存が無効になる。
+- 各必須項目を空/不正にしたとき、対応するメッセージが該当箇所に表示される。
+- 既存の正常系(全項目入力済み)で誤検知が出ない。
+- 全言語でメッセージキーが解決される(生キー文字列が出ない)。
+
+## テスト
+
+- 型変更ではなく挙動変更のため、`shopInfoValidator` のメッセージキーが正しく
+  該当フィールド名で生成されることを最低限手元で確認。
+- フロントは `yarn format` / `yarn lint` / `yarn build` を通す。

--- a/src/app/admin/Restaurants/Index.vue
+++ b/src/app/admin/Restaurants/Index.vue
@@ -116,7 +116,7 @@
               />
             </div>
             <div class="pl-4">
-              <state v-model="editShopInfo.state" />
+              <state v-model="editShopInfo.state" :error="errors['state']" />
             </div>
           </div>
           <!-- City -->
@@ -260,6 +260,12 @@
                 </div>
               </div>
             </div>
+            <p
+              v-if="errors['restProfilePhoto'].length > 0"
+              class="mt-1 text-sm font-bold text-red-700"
+            >
+              {{ $t(errors["restProfilePhoto"][0]) }}
+            </p>
 
             <!-- Description -->
             <div class="pt-2 text-sm text-black/60">
@@ -308,6 +314,12 @@
                 </div>
               </div>
             </div>
+            <p
+              v-if="errors['restCoverPhoto'].length > 0"
+              class="mt-1 text-sm font-bold text-red-700"
+            >
+              {{ $t(errors["restCoverPhoto"][0]) }}
+            </p>
             <!-- Description -->
             <div class="pt-2 text-sm text-black/60">
               {{ $t("editCommon.clickAndUploadDetail") }}
@@ -548,6 +560,12 @@
                     >
                   </div>
                 </div>
+                <p
+                  v-if="errors['pickUpMinimumCookTime'].length > 0"
+                  class="mt-1 text-sm font-bold text-red-700"
+                >
+                  {{ $t(errors["pickUpMinimumCookTime"][0]) }}
+                </p>
 
                 <div class="mt-2">
                   <template
@@ -578,7 +596,12 @@
                 </div>
                 <select
                   v-model.number="editShopInfo.pickUpDaysInAdvance"
-                  class="mt-1 rounded-lg border border-teal-400 bg-white px-3 py-2 hover:border-teal-400 focus:ring-teal-400"
+                  class="mt-1 rounded-lg border bg-white px-3 py-2 focus:ring-teal-400"
+                  :class="
+                    errors['pickUpDaysInAdvance'].length > 0
+                      ? 'border-red-500 hover:border-red-500'
+                      : 'border-teal-400 hover:border-teal-400'
+                  "
                 >
                   <option
                     v-for="(day, index) in reservationTheDayBefore"
@@ -588,6 +611,12 @@
                     {{ $t(day.messageKey) }}
                   </option>
                 </select>
+                <p
+                  v-if="errors['pickUpDaysInAdvance'].length > 0"
+                  class="mt-1 text-sm font-bold text-red-700"
+                >
+                  {{ $t(errors["pickUpDaysInAdvance"][0]) }}
+                </p>
               </div>
             </div>
           </div>
@@ -867,6 +896,12 @@
                         :{{ $t("shopInfo.lunch") }}
                       </div>
                     </div>
+                    <p
+                      v-if="errors['time'][index][0].length > 0"
+                      class="mt-1 text-sm font-bold text-red-700"
+                    >
+                      {{ $t(errors["time"][index][0][0]) }}
+                    </p>
                   </div>
 
                   <!-- Another Hours -->
@@ -891,6 +926,12 @@
                         :{{ $t("shopInfo.dinner") }}
                       </div>
                     </div>
+                    <p
+                      v-if="errors['time'][index][1].length > 0"
+                      class="mt-1 text-sm font-bold text-red-700"
+                    >
+                      {{ $t(errors["time"][index][1][0]) }}
+                    </p>
                   </div>
                 </div>
               </div>

--- a/src/app/admin/inputComponents/State.vue
+++ b/src/app/admin/inputComponents/State.vue
@@ -1,24 +1,34 @@
 <template>
   <div>
     <div class="pb-2 text-sm font-bold">
-      {{ $t(this.state_key) }}
+      {{ $t(state_key) }}
       <span class="text-red-700">*</span>
     </div>
     <select
       :value="modelValue"
-      placeholder="select"
       @change="input"
-      class="rounded-lg border border-teal-400 bg-white px-3 py-2 hover:border-teal-400 focus:ring-teal-400"
+      class="rounded-lg border bg-white px-3 py-2 focus:ring-teal-400"
+      :class="
+        error.length > 0
+          ? 'border-red-500 hover:border-red-500'
+          : 'border-teal-400 hover:border-teal-400'
+      "
     >
+      <option value="" disabled>
+        {{ $t(state_key) }}
+      </option>
       <option v-for="stateItem in states" :key="stateItem" :value="stateItem">
         {{ stateItem }}
       </option>
     </select>
+    <p v-if="error.length > 0" class="mt-1 text-sm font-bold text-red-700">
+      {{ $t(error[0]) }}
+    </p>
   </div>
 </template>
 
 <script lang="ts">
-import { defineComponent } from "vue";
+import { defineComponent, PropType } from "vue";
 
 import { regionalSetting } from "@/utils/utils";
 
@@ -28,6 +38,11 @@ export default defineComponent({
     modelValue: {
       type: String,
       required: true,
+    },
+    error: {
+      type: Array as PropType<string[]>,
+      required: false,
+      default: () => [],
     },
   },
   emits: ["update:modelValue"],

--- a/src/app/admin/inputComponents/TextForm.vue
+++ b/src/app/admin/inputComponents/TextForm.vue
@@ -29,6 +29,9 @@
         class="input w-full rounded border bg-white px-3 py-2"
         :class="error.length > 0 ? 'border-red-500' : 'border-gray-300'"
       />
+      <p v-if="error.length > 0" class="mt-1 text-sm font-bold text-red-700">
+        {{ $t(error[0]) }}
+      </p>
     </div>
   </div>
 </template>

--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -1499,6 +1499,54 @@ const data = {
     reset: "Reset Server URL",
   },
   validationError: {
+    restaurantName: {
+      empty: "Please enter the restaurant name",
+    },
+    ownerName: {
+      empty: "Please enter the owner's name",
+    },
+    streetAddress: {
+      empty: "Please enter the street address",
+    },
+    city: {
+      empty: "Please enter the city",
+    },
+    state: {
+      empty: "Please select the prefecture",
+    },
+    url: {
+      invalidUrl:
+        "Please enter a valid URL (starting with http:// or https://)",
+    },
+    lineUrl: {
+      invalidUrl:
+        "Please enter a valid URL (starting with http:// or https://)",
+    },
+    instagramUrl: {
+      invalidUrl:
+        "Please enter a valid URL (starting with http:// or https://)",
+    },
+    uberEatsUrl: {
+      invalidUrl:
+        "Please enter a valid URL (starting with http:// or https://)",
+    },
+    pickUpMinimumCookTime: {
+      tooMuch: "Preparation time is too long (up to 7 days)",
+      negative: "Preparation time cannot be negative",
+      notNumbery: "Please enter the preparation time as a number",
+    },
+    pickUpDaysInAdvance: {
+      invalid: "The reservation start day setting is invalid",
+    },
+    restProfilePhoto: {
+      empty: "Please set a profile photo",
+    },
+    restCoverPhoto: {
+      empty: "Please set a cover photo",
+    },
+    oneInEmpty: "Please enter both the start and end times",
+    validBusinessTime: "The end time must be later than the start time",
+    noSelect: "Please set the business hours",
     zip: {
       empty: "Please enter your zip code",
       invalidZip: "Please enter your valid zip code",

--- a/src/lang/fr.ts
+++ b/src/lang/fr.ts
@@ -1524,6 +1524,56 @@ const data = {
     reset: "Reset Server URL",
   },
   validationError: {
+    restaurantName: {
+      empty: "Veuillez saisir le nom du restaurant",
+    },
+    ownerName: {
+      empty: "Veuillez saisir le nom du responsable",
+    },
+    streetAddress: {
+      empty: "Veuillez saisir l'adresse (numéro et rue)",
+    },
+    city: {
+      empty: "Veuillez saisir la ville",
+    },
+    state: {
+      empty: "Veuillez sélectionner la préfecture",
+    },
+    url: {
+      invalidUrl:
+        "Veuillez saisir une URL valide (commençant par http:// ou https://)",
+    },
+    lineUrl: {
+      invalidUrl:
+        "Veuillez saisir une URL valide (commençant par http:// ou https://)",
+    },
+    instagramUrl: {
+      invalidUrl:
+        "Veuillez saisir une URL valide (commençant par http:// ou https://)",
+    },
+    uberEatsUrl: {
+      invalidUrl:
+        "Veuillez saisir une URL valide (commençant par http:// ou https://)",
+    },
+    pickUpMinimumCookTime: {
+      tooMuch: "Le temps de préparation est trop long (7 jours maximum)",
+      negative: "Le temps de préparation ne peut pas être négatif",
+      notNumbery:
+        "Veuillez saisir le temps de préparation sous forme de nombre",
+    },
+    pickUpDaysInAdvance: {
+      invalid: "Le réglage du jour de début des réservations est invalide",
+    },
+    restProfilePhoto: {
+      empty: "Veuillez définir une photo de profil",
+    },
+    restCoverPhoto: {
+      empty: "Veuillez définir une photo de couverture",
+    },
+    oneInEmpty: "Veuillez saisir l'heure de début et l'heure de fin",
+    validBusinessTime:
+      "L'heure de fin doit être postérieure à l'heure de début",
+    noSelect: "Veuillez définir les horaires d'ouverture",
     zip: {
       empty: "Veuillez saisir votre code postal",
       invalidZip: "Veuillez saisir un code postal valide",

--- a/src/lang/id.ts
+++ b/src/lang/id.ts
@@ -1513,6 +1513,54 @@ const data = {
     reset: "Reset URL server",
   },
   validationError: {
+    restaurantName: {
+      empty: "Silakan masukkan nama restoran",
+    },
+    ownerName: {
+      empty: "Silakan masukkan nama penanggung jawab",
+    },
+    streetAddress: {
+      empty: "Silakan masukkan alamat (nomor dan jalan)",
+    },
+    city: {
+      empty: "Silakan masukkan kota/kabupaten",
+    },
+    state: {
+      empty: "Silakan pilih prefektur",
+    },
+    url: {
+      invalidUrl:
+        "Silakan masukkan URL yang valid (diawali dengan http:// atau https://)",
+    },
+    lineUrl: {
+      invalidUrl:
+        "Silakan masukkan URL yang valid (diawali dengan http:// atau https://)",
+    },
+    instagramUrl: {
+      invalidUrl:
+        "Silakan masukkan URL yang valid (diawali dengan http:// atau https://)",
+    },
+    uberEatsUrl: {
+      invalidUrl:
+        "Silakan masukkan URL yang valid (diawali dengan http:// atau https://)",
+    },
+    pickUpMinimumCookTime: {
+      tooMuch: "Waktu persiapan terlalu lama (maksimal 7 hari)",
+      negative: "Waktu persiapan tidak boleh negatif",
+      notNumbery: "Silakan masukkan waktu persiapan dalam bentuk angka",
+    },
+    pickUpDaysInAdvance: {
+      invalid: "Pengaturan hari mulai pemesanan tidak valid",
+    },
+    restProfilePhoto: {
+      empty: "Silakan atur foto profil",
+    },
+    restCoverPhoto: {
+      empty: "Silakan atur foto sampul",
+    },
+    oneInEmpty: "Silakan masukkan waktu mulai dan waktu selesai",
+    validBusinessTime: "Waktu selesai harus lebih lambat dari waktu mulai",
+    noSelect: "Silakan atur jam buka",
     zip: {
       empty: "Silakan masukkan kode pos",
       invalidZip: "Silakan masukkan kode pos 7 digit yang benar",

--- a/src/lang/ja.ts
+++ b/src/lang/ja.ts
@@ -1493,6 +1493,50 @@ const data = {
     reset: "サーバーURLリセット",
   },
   validationError: {
+    restaurantName: {
+      empty: "飲食店名を入力してください",
+    },
+    ownerName: {
+      empty: "責任者氏名を入力してください",
+    },
+    streetAddress: {
+      empty: "番地以下を入力してください",
+    },
+    city: {
+      empty: "市区町村を入力してください",
+    },
+    state: {
+      empty: "都道府県を選択してください",
+    },
+    url: {
+      invalidUrl: "正しいURL（http:// または https://）を入力してください",
+    },
+    lineUrl: {
+      invalidUrl: "正しいURL（http:// または https://）を入力してください",
+    },
+    instagramUrl: {
+      invalidUrl: "正しいURL（http:// または https://）を入力してください",
+    },
+    uberEatsUrl: {
+      invalidUrl: "正しいURL（http:// または https://）を入力してください",
+    },
+    pickUpMinimumCookTime: {
+      tooMuch: "準備時間が長すぎます（最大7日まで）",
+      negative: "準備時間に負の値は指定できません",
+      notNumbery: "準備時間は数値で入力してください",
+    },
+    pickUpDaysInAdvance: {
+      invalid: "予約受付開始日の設定が正しくありません",
+    },
+    restProfilePhoto: {
+      empty: "プロフィール画像を設定してください",
+    },
+    restCoverPhoto: {
+      empty: "カバー画像を設定してください",
+    },
+    oneInEmpty: "開始時刻と終了時刻の両方を入力してください",
+    validBusinessTime: "終了時刻は開始時刻より後にしてください",
+    noSelect: "営業時間を設定してください",
     zip: {
       empty: "郵便番号を入力してください",
       invalidZip: "正しい7桁の郵便番号を入力してください",

--- a/src/lang/ko.ts
+++ b/src/lang/ko.ts
@@ -1479,6 +1479,50 @@ const data = {
     reset: "서버 URL 재설정",
   },
   validationError: {
+    restaurantName: {
+      empty: "음식점명을 입력해 주세요",
+    },
+    ownerName: {
+      empty: "책임자 성명을 입력해 주세요",
+    },
+    streetAddress: {
+      empty: "번지 이하를 입력해 주세요",
+    },
+    city: {
+      empty: "시·구·정촌을 입력해 주세요",
+    },
+    state: {
+      empty: "도도부현을 선택해 주세요",
+    },
+    url: {
+      invalidUrl: "올바른 URL(http:// 또는 https://)을 입력해 주세요",
+    },
+    lineUrl: {
+      invalidUrl: "올바른 URL(http:// 또는 https://)을 입력해 주세요",
+    },
+    instagramUrl: {
+      invalidUrl: "올바른 URL(http:// 또는 https://)을 입력해 주세요",
+    },
+    uberEatsUrl: {
+      invalidUrl: "올바른 URL(http:// 또는 https://)을 입력해 주세요",
+    },
+    pickUpMinimumCookTime: {
+      tooMuch: "준비 시간이 너무 깁니다(최대 7일까지)",
+      negative: "준비 시간에 음수는 지정할 수 없습니다",
+      notNumbery: "준비 시간은 숫자로 입력해 주세요",
+    },
+    pickUpDaysInAdvance: {
+      invalid: "예약 접수 시작일 설정이 올바르지 않습니다",
+    },
+    restProfilePhoto: {
+      empty: "프로필 이미지를 설정해 주세요",
+    },
+    restCoverPhoto: {
+      empty: "커버 이미지를 설정해 주세요",
+    },
+    oneInEmpty: "시작 시각과 종료 시각을 모두 입력해 주세요",
+    validBusinessTime: "종료 시각은 시작 시각보다 뒤여야 합니다",
+    noSelect: "영업시간을 설정해 주세요",
     zip: {
       empty: "우편번호를 입력해 주세요",
       invalidZip: "올바른 우편번호를 입력해 주세요",

--- a/src/lang/th.ts
+++ b/src/lang/th.ts
@@ -1481,6 +1481,54 @@ const data = {
     reset: "รีเซ็ต URL เซิร์ฟเวอร์",
   },
   validationError: {
+    restaurantName: {
+      empty: "กรุณาป้อนชื่อร้านอาหาร",
+    },
+    ownerName: {
+      empty: "กรุณาป้อนชื่อผู้รับผิดชอบ",
+    },
+    streetAddress: {
+      empty: "กรุณาป้อนที่อยู่ (บ้านเลขที่และถนน)",
+    },
+    city: {
+      empty: "กรุณาป้อนเขต/อำเภอ",
+    },
+    state: {
+      empty: "กรุณาเลือกจังหวัด",
+    },
+    url: {
+      invalidUrl:
+        "กรุณาป้อน URL ที่ถูกต้อง (ขึ้นต้นด้วย http:// หรือ https://)",
+    },
+    lineUrl: {
+      invalidUrl:
+        "กรุณาป้อน URL ที่ถูกต้อง (ขึ้นต้นด้วย http:// หรือ https://)",
+    },
+    instagramUrl: {
+      invalidUrl:
+        "กรุณาป้อน URL ที่ถูกต้อง (ขึ้นต้นด้วย http:// หรือ https://)",
+    },
+    uberEatsUrl: {
+      invalidUrl:
+        "กรุณาป้อน URL ที่ถูกต้อง (ขึ้นต้นด้วย http:// หรือ https://)",
+    },
+    pickUpMinimumCookTime: {
+      tooMuch: "เวลาเตรียมนานเกินไป (สูงสุด 7 วัน)",
+      negative: "เวลาเตรียมต้องไม่เป็นค่าติดลบ",
+      notNumbery: "กรุณาป้อนเวลาเตรียมเป็นตัวเลข",
+    },
+    pickUpDaysInAdvance: {
+      invalid: "การตั้งค่าวันเริ่มรับการจองไม่ถูกต้อง",
+    },
+    restProfilePhoto: {
+      empty: "กรุณาตั้งค่ารูปโปรไฟล์",
+    },
+    restCoverPhoto: {
+      empty: "กรุณาตั้งค่ารูปหน้าปก",
+    },
+    oneInEmpty: "กรุณาป้อนทั้งเวลาเริ่มและเวลาสิ้นสุด",
+    validBusinessTime: "เวลาสิ้นสุดต้องอยู่หลังเวลาเริ่ม",
+    noSelect: "กรุณาตั้งค่าเวลาทำการ",
     zip: {
       empty: "กรุณาป้อนรหัสไปรษณีย์",
       invalidZip: "กรุณาป้อนรหัสไปรษณีย์ 7 หลักที่ถูกต้อง",

--- a/src/lang/vi.ts
+++ b/src/lang/vi.ts
@@ -1503,6 +1503,54 @@ const data = {
     reset: "Đặt lại URL máy chủ",
   },
   validationError: {
+    restaurantName: {
+      empty: "Vui lòng nhập tên nhà hàng",
+    },
+    ownerName: {
+      empty: "Vui lòng nhập tên người phụ trách",
+    },
+    streetAddress: {
+      empty: "Vui lòng nhập địa chỉ (số nhà và đường)",
+    },
+    city: {
+      empty: "Vui lòng nhập quận/huyện",
+    },
+    state: {
+      empty: "Vui lòng chọn tỉnh",
+    },
+    url: {
+      invalidUrl:
+        "Vui lòng nhập URL hợp lệ (bắt đầu bằng http:// hoặc https://)",
+    },
+    lineUrl: {
+      invalidUrl:
+        "Vui lòng nhập URL hợp lệ (bắt đầu bằng http:// hoặc https://)",
+    },
+    instagramUrl: {
+      invalidUrl:
+        "Vui lòng nhập URL hợp lệ (bắt đầu bằng http:// hoặc https://)",
+    },
+    uberEatsUrl: {
+      invalidUrl:
+        "Vui lòng nhập URL hợp lệ (bắt đầu bằng http:// hoặc https://)",
+    },
+    pickUpMinimumCookTime: {
+      tooMuch: "Thời gian chuẩn bị quá dài (tối đa 7 ngày)",
+      negative: "Thời gian chuẩn bị không được là số âm",
+      notNumbery: "Vui lòng nhập thời gian chuẩn bị dưới dạng số",
+    },
+    pickUpDaysInAdvance: {
+      invalid: "Cài đặt ngày bắt đầu nhận đặt chỗ không hợp lệ",
+    },
+    restProfilePhoto: {
+      empty: "Vui lòng đặt ảnh hồ sơ",
+    },
+    restCoverPhoto: {
+      empty: "Vui lòng đặt ảnh bìa",
+    },
+    oneInEmpty: "Vui lòng nhập cả thời gian bắt đầu và kết thúc",
+    validBusinessTime: "Thời gian kết thúc phải sau thời gian bắt đầu",
+    noSelect: "Vui lòng đặt giờ mở cửa",
     zip: {
       empty: "Vui lòng nhập mã bưu điện",
       invalidZip: "Vui lòng nhập mã bưu điện 7 chữ số chính xác",

--- a/src/lang/zh-CN.ts
+++ b/src/lang/zh-CN.ts
@@ -1425,6 +1425,50 @@ const data = {
     reset: "重置服务器 URL",
   },
   validationError: {
+    restaurantName: {
+      empty: "请输入餐厅名称",
+    },
+    ownerName: {
+      empty: "请输入负责人姓名",
+    },
+    streetAddress: {
+      empty: "请输入门牌号及以下地址",
+    },
+    city: {
+      empty: "请输入市区町村",
+    },
+    state: {
+      empty: "请选择都道府县",
+    },
+    url: {
+      invalidUrl: "请输入有效的URL（以 http:// 或 https:// 开头）",
+    },
+    lineUrl: {
+      invalidUrl: "请输入有效的URL（以 http:// 或 https:// 开头）",
+    },
+    instagramUrl: {
+      invalidUrl: "请输入有效的URL（以 http:// 或 https:// 开头）",
+    },
+    uberEatsUrl: {
+      invalidUrl: "请输入有效的URL（以 http:// 或 https:// 开头）",
+    },
+    pickUpMinimumCookTime: {
+      tooMuch: "准备时间过长（最多7天）",
+      negative: "准备时间不能为负数",
+      notNumbery: "请以数字输入准备时间",
+    },
+    pickUpDaysInAdvance: {
+      invalid: "预约受理开始日的设置不正确",
+    },
+    restProfilePhoto: {
+      empty: "请设置头像图片",
+    },
+    restCoverPhoto: {
+      empty: "请设置封面图片",
+    },
+    oneInEmpty: "请同时输入开始时间和结束时间",
+    validBusinessTime: "结束时间必须晚于开始时间",
+    noSelect: "请设置营业时间",
     zip: {
       empty: "请输入邮政编码",
       invalidZip: "请输入有效的邮政编码",

--- a/src/lang/zh-TW.ts
+++ b/src/lang/zh-TW.ts
@@ -1425,6 +1425,50 @@ const data = {
     reset: "重置伺服器 URL",
   },
   validationError: {
+    restaurantName: {
+      empty: "請輸入餐廳名稱",
+    },
+    ownerName: {
+      empty: "請輸入負責人姓名",
+    },
+    streetAddress: {
+      empty: "請輸入門牌號及以下地址",
+    },
+    city: {
+      empty: "請輸入市區町村",
+    },
+    state: {
+      empty: "請選擇都道府縣",
+    },
+    url: {
+      invalidUrl: "請輸入有效的URL（以 http:// 或 https:// 開頭）",
+    },
+    lineUrl: {
+      invalidUrl: "請輸入有效的URL（以 http:// 或 https:// 開頭）",
+    },
+    instagramUrl: {
+      invalidUrl: "請輸入有效的URL（以 http:// 或 https:// 開頭）",
+    },
+    uberEatsUrl: {
+      invalidUrl: "請輸入有效的URL（以 http:// 或 https:// 開頭）",
+    },
+    pickUpMinimumCookTime: {
+      tooMuch: "準備時間過長（最多7天）",
+      negative: "準備時間不能為負數",
+      notNumbery: "請以數字輸入準備時間",
+    },
+    pickUpDaysInAdvance: {
+      invalid: "預約受理開始日的設定不正確",
+    },
+    restProfilePhoto: {
+      empty: "請設定大頭貼圖片",
+    },
+    restCoverPhoto: {
+      empty: "請設定封面圖片",
+    },
+    oneInEmpty: "請同時輸入開始時間和結束時間",
+    validBusinessTime: "結束時間必須晚於開始時間",
+    noSelect: "請設定營業時間",
     zip: {
       empty: "請輸入郵政編碼",
       invalidZip: "請輸入有效的郵政編碼",

--- a/src/utils/admin/RestaurantPageUtils.ts
+++ b/src/utils/admin/RestaurantPageUtils.ts
@@ -168,17 +168,17 @@ export const shopInfoValidator = (
   if (Number.isInteger(shopInfo["pickUpMinimumCookTime"])) {
     if (shopInfo["pickUpMinimumCookTime"] > 24 * 60 * 7) {
       (err["pickUpMinimumCookTime"] as string[]).push(
-        "validationError." + name + ".tooMuch",
+        "validationError.pickUpMinimumCookTime.tooMuch",
       );
     }
     if (shopInfo["pickUpMinimumCookTime"] < 0) {
       (err["pickUpMinimumCookTime"] as string[]).push(
-        "validationError." + name + ".negative",
+        "validationError.pickUpMinimumCookTime.negative",
       );
     }
   } else {
     (err["pickUpMinimumCookTime"] as string[]).push(
-      "validationError." + name + ".notNumbery",
+      "validationError.pickUpMinimumCookTime.notNumbery",
     );
   }
 
@@ -189,7 +189,7 @@ export const shopInfoValidator = (
     )
   ) {
     (err["pickUpDaysInAdvance"] as string[]).push(
-      "validationError." + name + ".invalid",
+      "validationError.pickUpDaysInAdvance.invalid",
     );
   }
 


### PR DESCRIPTION
## Summary

店舗情報編集画面(`src/app/admin/Restaurants/Index.vue`)で、`shopInfoValidator` のエラーにより
保存ボタンが無効化(`disableSave = hasError && publicFlag`)されているのに、対応するエラーが
UI に表示されず、ユーザーが「なぜ保存できないのか」分からないケースを解消する。

特に **都道府県(`state`)** が顕著で、初期値 `""` かつ都道府県セレクトに空の選択肢が無いため、
見た目は先頭の都道府県が選択済みに見えるのに実値は `""` のまま → 無表示のまま保存不可になっていた。

調査の結果、エラーメッセージを実際に文言表示しているのは PhoneEntry のみで、他は赤枠/色のみ、
`state` と `pickUpDaysInAdvance` に至っては UI が一切無い、という状態だった。これらを横断的に修正する。

詳細な調査結果: #1748

## Items to Confirm / Review

- **i18n 翻訳(全9言語)**: `validationError` 配下に多数のキーを追加しています。日本語・英語以外
  (fr / id / ko / th / vi / zh-CN / zh-TW)の文言が各言語として自然か、特にご確認ください
  (`es.ts` はスタブのため対象外)。
- **`state` の空 option 仕様**: 未選択を示すため `<option value="" disabled>` を追加し、ラベルは
  既存の `state_key`(=「都道府県」)を流用しています。専用の「選択してください」キーを足す方が
  良いかは判断ください(現状は 赤枠＋赤字メッセージ＋グレーの未選択表示 で十分と判断)。
- **`TextForm.vue` の挙動変更**: 従来「赤枠のみ」だった必須テキスト項目に**メッセージ文言**を出すよう
  変更しました。当コンポーネントは本画面専用(他画面では未使用)であることを確認済みです。
- **`pickUpDaysInAdvance`**: 選択肢から外れた旧データ値のとき(`state` と同じ「見た目だけ有効」状態)に
  赤枠＋メッセージが出るようにしています。発生は稀ですが同一根本原因のため対応。

## User Prompt

> `src/app/admin/Restaurants/Index.vue` で保存できないけど validate エラーが UI に出ないケースがあるらしい。調査して。
>
> (調査後)state の修正は「エラー表示の追加」と「空 option の追加」の両方で対応してほしい。さらに同種の問題が他にもないかよく調べ、副次的に見つかった問題も含めて調査結果を issue にしてほしい。
>
> (修正範囲の確認に対し)全部まとめて修正してほしい。
>
> PR 化して、PR にテスト方法を書いてほしい。

## 背景・原因

- 保存ボタン: `:isDisabled="submitting || disableSave"` / `disableSave = hasError && publicFlag` /
  `hasError = countObj(errors) > 0` / `errors = shopInfoValidator(...)`。
- `shopInfoValidator` が返すエラー配列が1件でもあると保存が無効化されるが、その配列に対応する
  UI 表示が無い項目があると「保存不可なのに無表示」になる。
  - **完全に不可視(分類A)**: `state`, `pickUpDaysInAdvance`
  - **枠/色のみでメッセージ無し(分類B)**: `pickUpMinimumCookTime`, `time`(営業時間), `restProfilePhoto`, `restCoverPhoto`
  - **validator バグ(分類C)**: メッセージキーを宙に浮いた `name`(グローバル `window.name`)で
    組み立てており `validationError..tooMuch` のように壊れていた。

## 変更内容

| ファイル | 内容 |
| --- | --- |
| `src/utils/admin/RestaurantPageUtils.ts` | 分類C修正。`name` 誤用を `pickUpMinimumCookTime` / `pickUpDaysInAdvance` のリテラルキーへ |
| `src/app/admin/inputComponents/TextForm.vue` | `error` を枠線色だけでなくメッセージ文言として描画 |
| `src/app/admin/inputComponents/State.vue` | `error` プロップ追加＋メッセージ＋赤枠、未選択を示す `<option value="" disabled>` 追加 |
| `src/app/admin/Restaurants/Index.vue` | `<state :error>` 連携、`pickUpDaysInAdvance` / `pickUpMinimumCookTime` / `time`(各スロット) / プロフィール・カバー画像にメッセージ表示を追加 |
| `src/lang/*.ts`(9言語) | `validationError` 配下に必要キーを追加(`es.ts` はスタブのため対象外) |

## テスト方法

事前準備:

```bash
yarn install
cp src/config/default/ownplate-dev.ts src/config/project.ts   # 未設定の場合
yarn start
```

店舗オーナーでサインインし、`/admin/restaurants/{restaurantId}` の店舗情報編集画面を開く。

### 自動チェック(CI 相当)

```bash
yarn format
yarn lint     # dumpi18n + eslint(i18n キー検証含む)
yarn build    # vite-plugin-checker により型検査も実行される
```

→ いずれもエラーなく完了することを確認(本 PR では全て green)。

### 手動確認(挙動が変わった部分のみ)

「公開」(`publicFlag` = ON)の状態で各項目を不正にし、**該当箇所に赤字メッセージが表示され、
保存ボタンが無効化される**ことを確認する。値を正すとメッセージが消え、保存できることを確認する。

1. **都道府県(state)** ※本件の主対象
   - 都道府県を未選択(または `state` 未設定の店舗で開く)にする。
   - セレクトが「未選択(グレー表示)」＋赤枠になり、下に「都道府県を選択してください」が出る。
   - 公開状態で保存ボタンが無効。都道府県を選ぶとメッセージが消え保存可能になる。
2. **準備時間(pickUpMinimumCookTime)**
   - 入力欄に数値以外(例: `abc`)/負値/`10081` 以上 を入れ、各メッセージ
     (数値で入力 / 負の値不可 / 長すぎる)が出ることを確認。
3. **営業時間(time)**
   - 営業日の時間帯で「開始だけ/終了だけ入力」→「両方を入力してください」。
   - 「終了 < 開始」→「終了時刻は開始時刻より後にしてください」。
   - 営業日なのに時間未設定 → 「営業時間を設定してください」。
4. **各種 URL(url / lineUrl / instagramUrl / uberEatsUrl)**
   - `http(s)://` で始まらない文字列を入れ、「正しい URL …」メッセージが出ることを確認。
5. **必須テキスト(飲食店名 / 責任者氏名 / 市区町村 / 番地 / 郵便番号)**
   - 空にすると、各項目の下に「〜を入力してください」が表示される(従来は赤枠のみだった)。
6. **画像(プロフィール / カバー)**
   - 画像未設定で、画像ブロック下に「〜を設定してください」が表示される。
7. **予約受付開始日(pickUpDaysInAdvance)**(任意・旧データ向け)
   - Firestore で選択肢に無い値(例: `999`)に設定して開くと、赤枠＋「予約受付開始日の設定が
     正しくありません」が出ることを確認。
8. **正常系**
   - 全項目を正しく入力した状態で、誤検知のメッセージが出ず、公開のまま保存できることを確認。

### 多言語確認

言語を切り替え(または `src/config/project.ts` のロケール)、上記メッセージが各言語で
表示される(生のキー文字列にならない)ことを確認。

## 関連

- Issue: #1748

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Ensure restaurant admin form validation errors are surfaced in the UI so users understand why saving is blocked.

Bug Fixes:
- Correct shop info validator error key generation for pickup preparation time and reservation start day so i18n messages resolve properly.

Enhancements:
- Display field-level validation messages for state, pickup preparation time, reservation start day, business hours, and restaurant images on the restaurant admin page.
- Extend the state selector component to support error display and an explicit unselected option, and update the shared text input component to render error messages below the field.
- Add a design/plan markdown document describing the background, approach, and verification for fixing hidden restaurant validation errors.

Documentation:
- Document the background, scope, and testing plan for the restaurant validation error UI fix in a dedicated markdown file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Validation errors now appear next to the relevant restaurant settings fields, including state, images, pickup settings, and business hours.
  * Fixed cases where saving was blocked but error messages were not shown.
  * Updated validation messages across supported languages for restaurant form inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->