### PR TITLE
fix: メニュー編集の商品名・値段のバリデーションエラーをUIに表示

### DIFF
--- a/plans/fix-menu-item-validation-error-ui.md
+++ b/plans/fix-menu-item-validation-error-ui.md
@@ -1,0 +1,30 @@
+# メニュー編集: itemName/price のバリデーションエラーメッセージを UI に表示
+
+関連 issue: https://github.com/Nakajima-Foundation/ownplate/issues/1750
+先行する同種修正(店舗情報編集): #1748 / PR #1749
+
+## 背景・課題
+
+`src/app/admin/Restaurants/MenuItemPage.vue` の必須項目 `itemName` / `price` は、バリデーション
+エラー時に赤枠が出るだけでエラーメッセージ文言が出ない(#1748 修正前の TextForm と同様)。
+原因項目を文言で明示する。
+
+- `validationError.itemName.empty` / `price.empty` の i18n キーは未定義。
+- `tax`(税区分)のエラーが UI に出ない問題は、既定 "food" で新規では起きず稀なため**据え置き**
+  (本 PR では扱わない)。
+
+## 対応方針(本 PR)
+
+1. **itemName / price**(`MenuItemPage.vue`)
+   - 入力欄の下にエラーメッセージ文言(赤字)を表示。
+2. **i18n**(`src/lang/*.ts`、es.ts はスタブのため対象外の9言語)
+   - `validationError.itemName.empty` / `price.empty` を追加。
+
+## 確認観点
+
+- 商品名 / 値段を空にすると、各入力欄の下にメッセージが表示される。
+- 正常系で誤検知が出ない。全言語でキーが解決される。
+
+## テスト
+
+- フロントは `yarn format` / `yarn lint` / `yarn build` を通す。

--- a/src/app/admin/Restaurants/MenuItemPage.vue
+++ b/src/app/admin/Restaurants/MenuItemPage.vue
@@ -98,6 +98,12 @@
                     : 'border-green-500'
                 "
               />
+              <p
+                v-if="errors['itemName'].length > 0"
+                class="mt-1 text-sm font-bold text-red-700"
+              >
+                {{ $t(errors["itemName"][0]) }}
+              </p>
             </div>
           </div>
 
@@ -143,6 +149,12 @@
                     {{ $t("currency." + currencyKey) }}
                   </span>
                 </div>
+                <p
+                  v-if="errors['price'].length > 0"
+                  class="mt-1 text-sm font-bold text-red-700"
+                >
+                  {{ $t(errors["price"][0]) }}
+                </p>
               </div>
             </div>
 

--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -1499,6 +1499,12 @@ const data = {
     reset: "Reset Server URL",
   },
   validationError: {
+    itemName: {
+      empty: "Please enter the item name",
+    },
+    price: {
+      empty: "Please enter the price",
+    },
     restaurantName: {
       empty: "Please enter the restaurant name",
     },

--- a/src/lang/fr.ts
+++ b/src/lang/fr.ts
@@ -1524,6 +1524,12 @@ const data = {
     reset: "Reset Server URL",
   },
   validationError: {
+    itemName: {
+      empty: "Veuillez saisir le nom de l'article",
+    },
+    price: {
+      empty: "Veuillez saisir le prix",
+    },
     restaurantName: {
       empty: "Veuillez saisir le nom du restaurant",
     },

--- a/src/lang/id.ts
+++ b/src/lang/id.ts
@@ -1513,6 +1513,12 @@ const data = {
     reset: "Reset URL server",
   },
   validationError: {
+    itemName: {
+      empty: "Silakan masukkan nama item",
+    },
+    price: {
+      empty: "Silakan masukkan harga",
+    },
     restaurantName: {
       empty: "Silakan masukkan nama restoran",
     },

--- a/src/lang/ja.ts
+++ b/src/lang/ja.ts
@@ -1493,6 +1493,12 @@ const data = {
     reset: "サーバーURLリセット",
   },
   validationError: {
+    itemName: {
+      empty: "商品名を入力してください",
+    },
+    price: {
+      empty: "値段を入力してください",
+    },
     restaurantName: {
       empty: "飲食店名を入力してください",
     },

--- a/src/lang/ko.ts
+++ b/src/lang/ko.ts
@@ -1479,6 +1479,12 @@ const data = {
     reset: "서버 URL 재설정",
   },
   validationError: {
+    itemName: {
+      empty: "상품명을 입력해 주세요",
+    },
+    price: {
+      empty: "가격을 입력해 주세요",
+    },
     restaurantName: {
       empty: "음식점명을 입력해 주세요",
     },

--- a/src/lang/th.ts
+++ b/src/lang/th.ts
@@ -1481,6 +1481,12 @@ const data = {
     reset: "รีเซ็ต URL เซิร์ฟเวอร์",
   },
   validationError: {
+    itemName: {
+      empty: "กรุณาป้อนชื่อสินค้า",
+    },
+    price: {
+      empty: "กรุณาป้อนราคา",
+    },
     restaurantName: {
       empty: "กรุณาป้อนชื่อร้านอาหาร",
     },

--- a/src/lang/vi.ts
+++ b/src/lang/vi.ts
@@ -1503,6 +1503,12 @@ const data = {
     reset: "Đặt lại URL máy chủ",
   },
   validationError: {
+    itemName: {
+      empty: "Vui lòng nhập tên món",
+    },
+    price: {
+      empty: "Vui lòng nhập giá",
+    },
     restaurantName: {
       empty: "Vui lòng nhập tên nhà hàng",
     },

--- a/src/lang/zh-CN.ts
+++ b/src/lang/zh-CN.ts
@@ -1425,6 +1425,12 @@ const data = {
     reset: "重置服务器 URL",
   },
   validationError: {
+    itemName: {
+      empty: "请输入商品名称",
+    },
+    price: {
+      empty: "请输入价格",
+    },
     restaurantName: {
       empty: "请输入餐厅名称",
     },

--- a/src/lang/zh-TW.ts
+++ b/src/lang/zh-TW.ts
@@ -1425,6 +1425,12 @@ const data = {
     reset: "重置伺服器 URL",
   },
   validationError: {
+    itemName: {
+      empty: "請輸入商品名稱",
+    },
+    price: {
+      empty: "請輸入價格",
+    },
     restaurantName: {
       empty: "請輸入餐廳名稱",
     },


### PR DESCRIPTION
## Summary

メニュー編集画面 `src/app/admin/Restaurants/MenuItemPage.vue` の必須項目 **商品名(`itemName`)/
値段(`price`)** が空のとき、従来は赤枠が出るだけでエラーメッセージ文言が無く、原因が分かりにくかった。
各入力欄の下にエラーメッセージを表示する。

先行する同種修正(店舗情報編集): #1748 / PR #1749 と同じ方針。

詳細: #1750

## Items to Confirm / Review

- **i18n 翻訳(全9言語)**: `validationError.itemName.empty` / `price.empty` を追加。日本語・英語以外
  (fr / id / ko / th / vi / zh-CN / zh-TW)の文言が自然かご確認ください(`es.ts` はスタブのため対象外)。
- **`tax`(税区分)は本 PR では据え置き**: `tax` のエラーが UI に出ない、より根の深い同種問題もあるが、
  既定値が `tax: "food"` で新規アイテムでは発生せず、`tax: ""` の旧データ/コピー由来でのみ起きる稀な
  ケースのため、今回はスコープ外としています(#1750 にも明記)。

## User Prompt

> `src/app/admin/Restaurants/MenuItemPage.vue` でも(店舗情報編集と)同様の問題がないか調べてほしい。
> もしあれば独立して issue と PR を作ってほしい。
>
> (調査後)税区分(tax)はたぶん今のままでよい。商品名(itemName)/値段(price)だけ対応してほしい。

## 背景・原因

`MenuItemPage.vue` のインライン validator は `itemName` / `price` / `tax` の空チェックを行い、
`hasError` で公開チェックボックス(`publicFlag`)を無効化(L56)＋ `draftWarning` を表示する(L63)。
ただし `itemName` / `price` は入力欄の赤枠(L96 / L135)で示すだけで、**どの項目をどう直せばよいかの
文言が無い**。`validationError.itemName.empty` / `price.empty` の i18n キーも未定義だった。

> 本画面の `hasError` は保存自体はブロックしない(常にドラフト保存可)。公開のみ無効化する。

## 変更内容

| ファイル | 内容 |
| --- | --- |
| `src/app/admin/Restaurants/MenuItemPage.vue` | `itemName` / `price` の入力欄下にエラーメッセージ文言(赤字)を表示 |
| `src/lang/*.ts`(9言語) | `validationError.itemName.empty` / `price.empty` を追加(`es.ts` はスタブのため対象外) |

## テスト方法

事前準備:

```bash
yarn install
cp src/config/default/ownplate-dev.ts src/config/project.ts   # 未設定の場合
yarn start
```

店舗オーナーでサインインし、`/admin/restaurants/{restaurantId}/menus/{menuId}` のメニュー編集画面を開く。

### 自動チェック(CI 相当)

```bash
yarn format
yarn lint     # dumpi18n + eslint(i18n キー検証含む)
yarn build    # vite-plugin-checker により型検査も実行される
```

→ いずれもエラーなく完了することを確認(本 PR では全て green)。

### 手動確認(挙動が変わった部分)

1. **商品名(itemName)**
   - 商品名を空にする → 入力欄が赤枠になり、下に「商品名を入力してください」が表示される。
   - 公開チェックボックスが無効化され、`draftWarning` が出る。
   - 商品名を入力するとメッセージが消える。
2. **値段(price)**
   - 値段を空にする → 入力欄が赤枠になり、下に「値段を入力してください」が表示される。
   - 値段を入力するとメッセージが消える。
3. **正常系**
   - 商品名・値段を正しく入力した状態で、誤検知のメッセージが出ないことを確認。
4. **多言語**
   - 言語を切り替え、上記メッセージが各言語で表示される(生のキー文字列にならない)ことを確認。

### スコープ外(確認不要)

- `tax`(税区分)のエラー非表示は本 PR では据え置き(#1750 参照)。

## 関連

- Issue: #1750
- 先行 PR(店舗情報編集): #1749

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Display validation error messages for required menu item fields in the admin menu editor and add corresponding i18n strings.

New Features:
- Show inline error messages under the item name and price inputs on the menu item edit page when validation fails.

Enhancements:
- Add localized validation messages for empty item name and price across supported languages in the i18n resources.
- Document the change and its scope in a planning markdown file under plans/.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Validation errors for item name and price now appear directly beneath the related fields, making form issues easier to spot.
  * Added missing localized error messages for empty item name and price fields across supported languages.

* **Documentation**
  * Added a planning document describing the updated validation behavior and verification checklist.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->