### PR TITLE
fix: CIのNodeを24.18.0に固定（Firebaseデプロイ復旧）

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,7 +17,9 @@ jobs:
       id-token: write
     strategy:
       matrix:
-        node-version: [24.x]
+        # Pin Node: 24.17.0 has a keep-alive regression (CVE-2026-48931) that breaks
+        # the WIF STS token exchange in `firebase deploy`. Fixed in 24.18.0.
+        node-version: [24.18.0]
 
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## 概要
`deploy.yml` の `node-version: [24.x]` がランナーで **24.17.0** に解決され、Firebase デプロイが `Failed to authenticate, have you run firebase login?` で失敗していた。

## 原因
- Node 24.17.0 の `http.Agent` 修正(**CVE-2026-48931**)が keep-alive ソケット再利用を壊し、googleapis への **STS トークン交換が `Premature close` で失敗**。
- firebase-tools が実エラーを握りつぶし、誤誘導の認証エラーを表示。**WIF/identity 連携自体は正常**(auth ステップは成功、creds 生成済み)。
- 失敗 run の実測: Node `v24.17.0` / firebase-tools `15.22.3`。最後の成功(6/22)は Node が壊れる前。

## 修正
- Node を **24.18.0**(修正版)に固定。`24.x` のままだと再びランナーが壊れた版を引く可能性があるため明示固定。

## 確認
- `pull_request.yaml` は googleapis 認証をしないため対象外。`deploy-old.yml` は非稼働(untracked)。

参考: [firebase-tools#10726](https://github.com/firebase/firebase-tools/issues/10726) / [nodejs/node#63989](https://github.com/nodejs/node/issues/63989)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

CI:
- Update the deploy GitHub Actions workflow to use a fixed Node.js 24.18.0 runtime instead of the floating 24.x matrix to prevent Firebase deploy failures.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deployment reliability by using a fixed Node.js version that avoids a known regression during release authentication.
  * Reduced the chance of failed deployment steps caused by token exchange issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->