### PR TITLE
ci: report code quality with scoria on pull requests

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -61,4 +61,8 @@ jobs:
     - run: yarn run lint
     - name: yarn build
       run: yarn run build
+
+    # Reports code quality scores and findings. Report-only: it never fails the build.
+    - name: scoria
+      run: npx -y scoria
       

--- a/scoria.config.json
+++ b/scoria.config.json
@@ -1,0 +1,9 @@
+{
+  "profile": "app",
+  "stacks": [
+    "vue",
+    "ts"
+  ],
+  "mode": "report",
+  "lang": "en"
+}


### PR DESCRIPTION
## Summary

Adds a report-only quality step to the `build-vue` job, and commits the configuration it reads.

```yaml
    # Reports code quality scores and findings. Report-only: it never fails the build.
    - name: scoria
      run: npx -y scoria
```

[scoria](https://www.npmjs.com/package/scoria) collects machine evidence about the repository —
suppressed type and lint errors, file sizes, untyped sources, gaps in the project's own gates — and
prints per-dimension scores. **It never fails the build**: `mode: report` is the default and the
command exits 0 whatever it finds.

Current output for this repository:

```text
407 files · 56569 sloc · 1456 test sloc   config: config-file

  Dimension            Score   Confidence
  ──────────────────────────────────────────────────────────────
  integrity               66   high
  readability             29   high
  type-safety             97   high
  ──────────────────────────────────────────────────────────────
  Overall                 64   not comparable across repos

8 findings at severity error
  src/components/CustomerInfo.vue:108  eslint-disable-no-reason  suppresses an ESLint rule, with no reason given
  ...

63 warnings
  god-file                 21
  untyped-source           42
```

## Items to Confirm / Review

1. **The scores are not comparable to any other repository** and are not meant to be. Normalisation,
   the active probes and the strictness of a project's own gates all differ between projects. What
   the number is for is watching this repository's own trend, so the first few runs are only a
   baseline. Ratchet gating on regression is not implemented yet.

2. **`scoria.config.json` is committed on purpose.** It records the detected stack (`vue`, `ts`) so
   the measurement does not shift when a dependency is added — otherwise one new package changes
   which probes run, and the trend stops meaning anything. Without the file, CI reports that the
   detection is not frozen on every run.

3. **The version is not pinned** (`npx -y scoria`), so improvements arrive automatically. Since the
   step only reports, a change in scoria cannot break this build — but the output can change
   without a commit here. Pin it to `scoria@0.0.2` if you would rather it did not.

4. **The step runs after `build`.** If lint or build fails, the job stops before it and no report is
   produced. That seemed better than reporting quality for a tree that does not compile.

5. **Most error findings are suppressions without a stated reason** — for example
   `src/components/CustomerInfo.vue:108`, where the prose above the directive does explain why
   `no-new` is disabled, but not in ESLint's `--` form. Adding `-- reason` after the rule name is
   enough to clear those; scoria follows ESLint's own convention and deliberately does not accept a
   rule name as a justification.

## Notes

`scoria doctor` reports four setup gaps in this repository, none of which this PR changes:

- no `test` script
- no `typecheck` script
- CI does not run `typecheck`
- CI does not run `test`

Those are worth a separate conversation rather than being folded in here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ndh1jN9pv9dxAWVCV1MjyD

## Summary by Sourcery

Add Scoria-based code-quality reporting and freeze its repository configuration for consistent pull-request measurements.

Enhancements:
- Add report-only Scoria code-quality reporting to the pull request build workflow.
- Commit Scoria configuration to keep repository quality measurements consistent over time.

CI:
- Run Scoria after the build to report quality scores and findings without affecting job success.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added automated code quality reporting to the build process.
  - Build results now include quality scores and findings for easier review.

- **Chores**
  - Configured project-specific settings for consistent quality analysis.
  - Quality checks report findings without blocking successful builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->